### PR TITLE
core: Remove compile time backend switches.

### DIFF
--- a/smaug/core/backend.h
+++ b/smaug/core/backend.h
@@ -6,18 +6,7 @@
 #include "smaug/core/datatypes.h"
 #include "smaug/utility/utils.h"
 
-// These are compile-time switches that selectively build a copy of SMAUG with
-// a particular backend.
-#define REFERENCE 0
-#define SMVBACKEND 1
-
 namespace smaug {
-
-enum BackendName {
-    Reference = REFERENCE,
-    Smv = SMVBACKEND,
-    UnknownBackend,
-};
 
 class Workspace;
 template <typename Backend> class ConvolutionOp;


### PR DESCRIPTION
These were not used after we encoded the backend information in the
graph proto.