### PR TITLE
core: Fix scheduler.

### DIFF
--- a/smaug/core/scheduler.cpp
+++ b/smaug/core/scheduler.cpp
@@ -42,8 +42,9 @@ Tensor* Scheduler::runNetwork() {
     for (auto nameOp : network->getOperators()) {
         Operator* op = nameOp.second;
         Vertex vertex = op->getVertex();
-        op->setNumPendingInputs(boost::in_degree(vertex, network->getGraph()));
-        if (op->getOpType() == OpType::Data)
+        int numPendingInputs = boost::in_degree(vertex, network->getGraph());
+        op->setNumPendingInputs(numPendingInputs);
+        if (numPendingInputs == 0)
             readyQueue.push_back(op);
     }
     Tensor* output;


### PR DESCRIPTION
We should kick off the scheduling by putting operators to the ready
queue if they don't any pending inputs. The data op shouldn't be taken
specially here.

TESTED=all tests are still passing