### PR TITLE
python: Deduplicate data ops created for input tensors

### DIFF
--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -99,6 +99,7 @@ PY_TESTS = smaug/python/tensor_test.py \
            smaug/python/unique_name_test.py \
            smaug/python/ops/ops_test.py \
            smaug/python/ops/fp_precision_test.py \
+           smaug/python/ops/data_op_test.py \
            smaug/python/ops/activation_ops_test.py \
            smaug/python/ops/recurrent_test.py \
            smaug/python/ops/attention_test.py

--- a/smaug/python/graph.py
+++ b/smaug/python/graph.py
@@ -113,11 +113,9 @@ class Graph:
     """Return nodes in the graph proto."""
     return self.graph.nodes
 
-  def find_data_op_output(self, tensor_name):
+  def get_tensor_data_op(self, tensor_name):
     """Return the output of the data op if one is created for this tensor."""
-    if tensor_name in self._tensor_data_op_map:
-      return self._tensor_data_op_map[tensor_name]
-    return None
+    return self._tensor_data_op_map.get(tensor_name, None)
 
   def create_unique_name(self, name, mark_as_used=True):
     """ Create a unique name for the node.

--- a/smaug/python/graph.py
+++ b/smaug/python/graph.py
@@ -24,6 +24,10 @@ class Graph:
     self.layout_trans_enabled = True
     # This proto stores all the parameters in the network.
     self.tensor_data_array = tensor_pb2.TensorDataArray()
+    # We create a data op for every input tensor. To avoid adding extraneous
+    # data ops, this tracks the pairs of a tensor and its corresponding data
+    # op's output.
+    self._tensor_data_op_map = {}
 
   def __enter__(self):
     if global_vars.get_graph() != None:
@@ -93,6 +97,9 @@ class Graph:
       output_tensor.to_tensor_proto(output_tensor_proto, self.tensor_data_array)
       output_tensors.append(output_tensor)
 
+    if node.op == types_pb2.Data:
+      self._tensor_data_op_map[input_tensors[0].name] = output_tensors[0]
+
     return output_tensors
 
   def get_node(self, node_name):
@@ -105,6 +112,12 @@ class Graph:
   def get_nodes(self):
     """Return nodes in the graph proto."""
     return self.graph.nodes
+
+  def find_data_op_output(self, tensor_name):
+    """Return the output of the data op if one is created for this tensor."""
+    if tensor_name in self._tensor_data_op_map:
+      return self._tensor_data_op_map[tensor_name]
+    return None
 
   def create_unique_name(self, name, mark_as_used=True):
     """ Create a unique name for the node.

--- a/smaug/python/ops/common.py
+++ b/smaug/python/ops/common.py
@@ -43,11 +43,11 @@ def add_node(
     output_tensor_layout = input_tensors[0].shape.layout
 
   # If any input tensor doesn't have a source operator, we create a DataOp
-  # for it. This makes the deserializing a lot easier in the C++ core. Note
-  # that we don't need to create a DataOp for input_data.
+  # for it. This makes the deserializing a lot easier in the C++ core. To avoid
+  # deadlock, don't create a new data op if the node to be added is a data op.
   for i in range(len(input_tensors)):
     if input_tensors[i].source == None and op != types_pb2.Data:
-      data_op_output = global_vars.get_graph().find_data_op_output(
+      data_op_output = global_vars.get_graph().get_tensor_data_op(
           input_tensors[i].name)
       if data_op_output is not None:
         input_tensors[i] = data_op_output

--- a/smaug/python/ops/common.py
+++ b/smaug/python/ops/common.py
@@ -47,12 +47,17 @@ def add_node(
   # that we don't need to create a DataOp for input_data.
   for i in range(len(input_tensors)):
     if input_tensors[i].source == None and op != types_pb2.Data:
+      data_op_output = global_vars.get_graph().find_data_op_output(
+          input_tensors[i].name)
+      if data_op_output is not None:
+        input_tensors[i] = data_op_output
+        continue
       input_tensors[i] = global_vars.get_graph().add_node(
           name="data", op=types_pb2.Data, input_tensors=[input_tensors[i]],
           output_tensors_dims=[input_tensors[i].shape.dims],
           output_tensor_layout=input_tensors[i].shape.layout,
-          output_tensor_dtype=output_tensor_dtype,
-          output_tensor_dformat=output_tensor_dformat)[0]
+          output_tensor_dtype=input_tensors[i].data_type,
+          output_tensor_dformat=input_tensors[i].data_format)[0]
   return global_vars.get_graph().add_node(
       name=name, op=op, input_tensors=input_tensors,
       output_tensors_dims=output_tensors_dims,

--- a/smaug/python/ops/data_op_test.py
+++ b/smaug/python/ops/data_op_test.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+import unittest
+import numpy as np
+
+from smaug.core import types_pb2
+from smaug.python.tensor import Tensor
+from smaug.python.graph import Graph
+from smaug.python.ops import data_op
+from smaug.python.ops import math_ops
+
+graph_name = "test_graph"
+backend = "Reference"
+x = Tensor(
+    data_layout=types_pb2.N, tensor_data=np.random.rand(4).astype(np.float32))
+y = Tensor(
+    data_layout=types_pb2.N, tensor_data=np.random.rand(4).astype(np.float32))
+
+def get_num_data_nodes(graph):
+  return len(
+      [node.name for node in graph.get_nodes() if node.op == types_pb2.Data])
+
+class TestUniqueName(unittest.TestCase):
+  def test_data_op0(self):
+    with Graph(graph_name, backend) as test_graph:
+      res= math_ops.add(x, y)
+    self.assertEqual(get_num_data_nodes(test_graph), 2)
+
+  def test_data_op1(self):
+    with Graph(graph_name, backend) as test_graph:
+      x_ = data_op.input_data(x)
+      res= math_ops.add(x_, y)
+    self.assertEqual(get_num_data_nodes(test_graph), 2)
+
+  def test_data_op2(self):
+    with Graph(graph_name, backend) as test_graph:
+      x_ = data_op.input_data(x)
+      res= math_ops.add(x, y)
+    self.assertEqual(get_num_data_nodes(test_graph), 2)
+
+  def test_data_op3(self):
+    with Graph(graph_name, backend) as test_graph:
+      res = math_ops.add(x, y)
+      res = math_ops.mul(x, res)
+    self.assertEqual(get_num_data_nodes(test_graph), 2)
+
+if __name__ == "__main__":
+  unittest.main()

--- a/smaug/python/ops/data_op_test.py
+++ b/smaug/python/ops/data_op_test.py
@@ -17,28 +17,31 @@ y = Tensor(
     data_layout=types_pb2.N, tensor_data=np.random.rand(4).astype(np.float32))
 
 def get_num_data_nodes(graph):
-  return len(
-      [node.name for node in graph.get_nodes() if node.op == types_pb2.Data])
+  count = 0
+  for node in graph.get_nodes():
+    if node.op == types_pb2.Data:
+      count += 1
+  return count
 
 class TestUniqueName(unittest.TestCase):
-  def test_data_op0(self):
+  def test_auto_data_op(self):
     with Graph(graph_name, backend) as test_graph:
       res= math_ops.add(x, y)
     self.assertEqual(get_num_data_nodes(test_graph), 2)
 
-  def test_data_op1(self):
+  def test_no_extra_data_op(self):
     with Graph(graph_name, backend) as test_graph:
       x_ = data_op.input_data(x)
-      res= math_ops.add(x_, y)
-    self.assertEqual(get_num_data_nodes(test_graph), 2)
+      res= math_ops.add(x_, x)
+    self.assertEqual(get_num_data_nodes(test_graph), 1)
 
-  def test_data_op2(self):
+  def test_use_existing_data_op(self):
     with Graph(graph_name, backend) as test_graph:
       x_ = data_op.input_data(x)
       res= math_ops.add(x, y)
     self.assertEqual(get_num_data_nodes(test_graph), 2)
 
-  def test_data_op3(self):
+  def test_shared_data_op(self):
     with Graph(graph_name, backend) as test_graph:
       res = math_ops.add(x, y)
       res = math_ops.mul(x, res)


### PR DESCRIPTION
python: Deduplicate data ops.

Previously if multiple operators share the same input tensor, we
would create duplicated data ops. This adds some tracking info to
deduplicate data ops.

TESTED=unit