### PR TITLE
python: Fix a bug in creating unique names.

### DIFF
--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -96,6 +96,7 @@ TESTS = smaug/core/tensor_test.cpp \
         smaug/operators/smv/smv_eltwise_ops_test.cpp \
         smaug/operators/smv/kernels/load_store_fp16_data_test.cpp
 PY_TESTS = smaug/python/tensor_test.py \
+           smaug/python/unique_name_test.py \
            smaug/python/ops/ops_test.py \
            smaug/python/ops/activation_ops_test.py \
            smaug/python/ops/recurrent_test.py \

--- a/smaug/python/graph.py
+++ b/smaug/python/graph.py
@@ -15,7 +15,7 @@ class Graph:
       mem_policy=types_pb2.AllDma):
     assert (backend in global_vars.backend_alignment)
     self.graph = graph_pb2.GraphProto()
-    self.node_names = {}
+    self._node_names = {}
     self.graph.name = name
     self.graph.backend = backend
     self.graph.mem_policy = mem_policy
@@ -60,7 +60,7 @@ class Graph:
       The output tensor of the added node.
     """
     node = self.graph.nodes.add()
-    node.name = self._create_unique_name(name)
+    node.name = self.create_unique_name(name)
     node.op = op
 
     # Add the parameters to the node.
@@ -102,18 +102,31 @@ class Graph:
         return self.graph.nodes[i]
     return None
 
-  def _create_unique_name(self, name):
+  def get_nodes(self):
+    """Return nodes in the graph proto."""
+    return self.graph.nodes
+
+  def create_unique_name(self, name, mark_as_used=True):
     """ Create a unique name for the node.
 
     Args:
       name: The node's name.
     """
-    if name not in self.node_names:
-      self.node_names[name] = 0
+    if name not in self._node_names:
+      self._node_names[name] = 0
       return name
     else:
-      self.node_names[name] += 1
-      return name + "_%d" % self.node_names[name]
+      self._node_names[name] += 1
+      new_name = "%s_%d" % (name, self._node_names[name])
+      # Make sure the new name is not already used.
+      while new_name in self._node_names:
+        self._node_names[name] += 1
+        new_name = "%s_%d" % (name, self._node_names[name])
+      # Mark the new name as used in case someone wants to call
+      # create_unique_name("name_1").
+      if mark_as_used:
+        self._node_names[new_name] = 0
+      return new_name
 
   def disable_layout_transform(self):
     """Disable automatic layout transformation.

--- a/smaug/python/graph.py
+++ b/smaug/python/graph.py
@@ -116,12 +116,12 @@ class Graph:
       self._node_names[name] = 0
       return name
     else:
-      self._node_names[name] += 1
-      new_name = "%s_%d" % (name, self._node_names[name])
-      # Make sure the new name is not already used.
-      while new_name in self._node_names:
+      while True:
         self._node_names[name] += 1
         new_name = "%s_%d" % (name, self._node_names[name])
+        # Make sure the new name is not already used.
+        if new_name not in self._node_names:
+          break
       # Mark the new name as used in case someone wants to call
       # create_unique_name("name_1").
       if mark_as_used:

--- a/smaug/python/unique_name_test.py
+++ b/smaug/python/unique_name_test.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+
+""" This tests the unique name creation in the Graph class."""
+
+import unittest
+import numpy as np
+
+from smaug.core import types_pb2
+from smaug.python.tensor import Tensor
+from smaug.python.graph import Graph
+from smaug.python.ops import math_ops
+
+graph_name = "test_graph"
+backend = "Reference"
+x = Tensor(
+    data_layout=types_pb2.N, tensor_data=np.random.rand(4).astype(np.float32))
+y = Tensor(
+    data_layout=types_pb2.N, tensor_data=np.random.rand(4).astype(np.float32))
+
+def get_node_names(graph):
+  return set([node.name for node in graph.get_nodes()])
+
+class TestUniqueName(unittest.TestCase):
+  def test_default_names(self):
+    with Graph(graph_name, backend) as test_graph:
+      res= math_ops.add(x, y)
+      res = math_ops.mul(x, res)
+    self.assertEqual(get_node_names(test_graph), {"add", "mul"})
+
+  def test_auto_unique_names(self):
+    with Graph(graph_name, backend) as test_graph:
+      res = math_ops.add(x, y)
+      res = math_ops.add(res, res)
+      res = math_ops.add(res, res)
+    self.assertEqual(get_node_names(test_graph), {"add", "add_1", "add_2"})
+
+  def test_user_supplied_names0(self):
+    with Graph(graph_name, backend) as test_graph:
+      res = math_ops.add(x, y, name="add")
+      res = math_ops.mul(res, res, name="mul")
+    self.assertEqual(get_node_names(test_graph), {"add", "mul"})
+
+  def test_user_supplied_names1(self):
+    with Graph(graph_name, backend) as test_graph:
+      res = math_ops.add(x, y, name="add")
+      res = math_ops.add(res, res, name="add_1")
+      res = math_ops.add(res, res, name="add")
+    self.assertEqual(get_node_names(test_graph), {"add", "add_1", "add_2"})
+
+  def test_user_supplied_names1(self):
+    with Graph(graph_name, backend) as test_graph:
+      res = math_ops.add(x, y, name="add")
+      res = math_ops.add(res, res, name="add_3")
+      res = math_ops.add(res, res, name="add")
+    self.assertEqual(get_node_names(test_graph), {"add", "add_1", "add_3"})
+
+  def test_user_supplied_names2(self):
+    with Graph(graph_name, backend) as test_graph:
+      res = math_ops.add(x, y, name="add")
+      res = math_ops.add(res, res, name="add_1")
+      res = math_ops.add(res, res, name="add_1")
+    self.assertEqual(get_node_names(test_graph), {"add", "add_1", "add_1_1"})
+
+  def test_user_supplied_names3(self):
+    with Graph(graph_name, backend) as test_graph:
+      res = math_ops.add(x, y, name="add")
+      unique_name = test_graph.create_unique_name("add", mark_as_used=False)
+      res = math_ops.add(res, res, name=unique_name)
+    self.assertEqual(get_node_names(test_graph), {"add", "add_1"})
+
+  def test_user_supplied_names4(self):
+    with Graph(graph_name, backend) as test_graph:
+      res = math_ops.add(x, y, name="add")
+      unique_name = test_graph.create_unique_name("add", mark_as_used=False)
+      res = math_ops.add(res, res, name=unique_name)
+      res = math_ops.add(res, res, name="add")
+    self.assertEqual(get_node_names(test_graph), {"add", "add_1", "add_2"})
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
When creating a unique name for the operator, the naming format is
"%(name)s_%(idx)d". If the name is already in use, we previously just
increased the idx. For example, if "add" is in use, "add_1" will be
used. However, this could mistakenly return a name already in use
as shown in the following example:

  ```python
  res = add(x, y) # This will be named "add".
  res = add(x, y, name="add_1") # This will be named "add_1".
  res = add(x, y) # BUG: this will also be named "add_1".
 ```

To solve this, we keep increasing the idx until the new name is not
in use. In the above example, the third add will now be named "add_2".

This also makes create_unique_name() public, so the user can get a
unique name before the operator is created. Example:

  ```python
  res = add(x, y) # This will be named "add".
  # Get a unique name for the operator to be added. Note that
  # `mark_as_used` is set to False in order to avoid re-creating a
  # name for the operator. This returns "add_1".
  unique_name =
      global_vars.get_graph().create_unique_name(
          "add", mark_as_used=False)
  res = add(res, res, name=unique_name) # This will be named "add_1".
  ```

TESTED=unit