### PR TITLE
python: Fix a bug in create_unique_name.

### DIFF
--- a/smaug/python/graph.py
+++ b/smaug/python/graph.py
@@ -110,23 +110,21 @@ class Graph:
     """ Create a unique name for the node.
 
     Args:
-      name: The node's name.
+      name: The base name used to create the unique name.
+      mark_as_used: Mark the unique name as used so if someone wants to call
+        create_unique_name(unique_name), a different name will be created.
     """
-    if name not in self._node_names:
-      self._node_names[name] = 0
-      return name
-    else:
+    new_name = name
+    if name in self._node_names:
       while True:
         self._node_names[name] += 1
         new_name = "%s_%d" % (name, self._node_names[name])
         # Make sure the new name is not already used.
         if new_name not in self._node_names:
           break
-      # Mark the new name as used in case someone wants to call
-      # create_unique_name("name_1").
-      if mark_as_used:
-        self._node_names[new_name] = 0
-      return new_name
+    if mark_as_used:
+      self._node_names[new_name] = 0
+    return new_name
 
   def disable_layout_transform(self):
     """Disable automatic layout transformation.

--- a/smaug/python/unique_name_test.py
+++ b/smaug/python/unique_name_test.py
@@ -77,5 +77,11 @@ class TestUniqueName(unittest.TestCase):
       res = math_ops.add(res, res, name="add")
     self.assertEqual(get_node_names(test_graph), {"add", "add_1", "add_2"})
 
+  def test_user_supplied_names5(self):
+    with Graph(graph_name, backend) as test_graph:
+      unique_name = test_graph.create_unique_name("add", mark_as_used=False)
+      res = math_ops.add(x, y, name=unique_name)
+    self.assertEqual(get_node_names(test_graph), {"add"})
+
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
This fixes a bug in PR #17.

The bug was that `mark_as_used` kwarg of `create_unique_name` would only be checked if the name was already in the set of used names.