### PR TITLE
core: Allow boost graph to have multiple edges between two vertices.

### DIFF
--- a/smaug/core/typedefs.h
+++ b/smaug/core/typedefs.h
@@ -29,7 +29,7 @@ namespace boost {
 
 typedef boost::property<boost::vertex_op_t, smaug::Operator*> VertexProperty;
 typedef boost::property<boost::edge_name_t, smaug::TensorIndices> EdgeProperty;
-typedef boost::adjacency_list<boost::setS,
+typedef boost::adjacency_list<boost::vecS,
                               boost::vecS,
                               boost::bidirectionalS,
                               VertexProperty,


### PR DESCRIPTION
The graph view of the network didn't allow multiple edges between two vertices.
This leads to inputs unconstructed when multiple operator inputs come from the same
input tensor, because the network builder only set an input for an operator if
there's an in_edge. This fixes the issue by making the boost graph use
std::vector to store the edges (instead of std::set), which thus can represent
multiple edges.