### PR TITLE
python: Add an FP precision test and relax test accuracy.

### DIFF
--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -98,6 +98,7 @@ TESTS = smaug/core/tensor_test.cpp \
 PY_TESTS = smaug/python/tensor_test.py \
            smaug/python/unique_name_test.py \
            smaug/python/ops/ops_test.py \
+           smaug/python/ops/fp_precision_test.py \
            smaug/python/ops/activation_ops_test.py \
            smaug/python/ops/recurrent_test.py \
            smaug/python/ops/attention_test.py

--- a/smaug/python/ops/array_ops.py
+++ b/smaug/python/ops/array_ops.py
@@ -1,4 +1,5 @@
 import numpy as np
+import warnings
 
 from smaug.core import types_pb2
 from smaug.core import node_pb2
@@ -96,7 +97,7 @@ def split(input_tensor, num_or_size_splits, axis=0, name="split"):
         "the sum (%d) of sizes along the split axis must match that of the "
         "input (%d)!" % (sum(splits), input_tensor.shape.dims[axis]))
   if splits == [1]:
-    warn(
+    warnings.warn(
         "Number of splits is 1 for the split operator, thus this operator is "
         "optimized out.")
     return [input_tensor]

--- a/smaug/python/ops/attention_test.py
+++ b/smaug/python/ops/attention_test.py
@@ -64,7 +64,7 @@ class AttentionTest(SmaugTest):
       cell_out, _ = sg_cell.step(
           concat([query, sg_initial_attention], axis=1), timestep=0)
       sg_attention(cell_out)
-    self.runAndValidate(graph, tf_attention)
+    self.runAndValidate(graph, tf_attention, decimal=2)
 
 if __name__ == "__main__":
   unittest.main()

--- a/smaug/python/ops/fp_precision_test.py
+++ b/smaug/python/ops/fp_precision_test.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+
+""" This tests operators that can potentially lead to FP precision loss."""
+
+import unittest
+import tensorflow as tf
+import numpy as np
+
+from smaug.core import types_pb2
+from smaug.python.smaug_test import SmaugTest
+from smaug.python.graph import Graph
+from smaug.python.tensor import Tensor
+from smaug.python.ops import nn_ops
+from smaug.python.ops import math_ops
+
+initializer = tf.random_normal_initializer(mean=0.0, stddev=0.01)
+
+class FpPrecisionTest(SmaugTest):
+  def test_mat_mul(self):
+    batch = 4
+    channels = 32
+    units = 128
+    tf_a = tf.Variable(initializer(shape=[batch, channels], dtype=self.dtype))
+    tf_b = tf.Variable(initializer(shape=[units, channels], dtype=self.dtype))
+    tf_result = tf.python.math_ops.matmul(tf_a, tf_b, transpose_b=True)
+
+    a = Tensor(data_layout=types_pb2.NC, tensor_data=tf_a.numpy())
+    b = Tensor(data_layout=types_pb2.NC, tensor_data=tf_b.numpy())
+    with Graph(name=self.graph_name, backend=self.backend) as graph:
+      nn_ops.mat_mul(a, b)
+    self.runAndValidate(graph, tf_result)
+
+  def test_convolution(self):
+    batch = 4
+    width = 8
+    height = 8
+    channels = 32
+    filter_height = 3
+    filter_width = 3
+    num_filters = 128
+    tf_inputs = tf.Variable(
+        initializer(shape=[batch, height, width, channels], dtype=self.dtype))
+    tf_filters = tf.Variable(
+        initializer(
+            shape=[filter_height, filter_width, channels, num_filters],
+            dtype=self.dtype))
+    tf_results = tf.python.nn_ops.conv2d(
+        tf_inputs, tf_filters, strides=[1, 1], padding="SAME",
+        data_format="NHWC", dilations=None)
+
+    inputs = Tensor(data_layout=types_pb2.NHWC, tensor_data=tf_inputs.numpy())
+    filters = Tensor(
+        data_layout=types_pb2.NHWC,
+        tensor_data=np.transpose(tf_filters.numpy(), (3, 0, 1, 2)))
+    with Graph(name=self.graph_name, backend=self.backend) as graph:
+      nn_ops.convolution(inputs, filters, stride=[1, 1], padding="same")
+    self.runAndValidate(graph, tf_results)
+
+  def test_add(self):
+    batch = 4
+    channels = 32
+    tf_a = tf.Variable(initializer(shape=[batch, channels], dtype=self.dtype))
+    tf_b = tf.Variable(initializer(shape=[batch, channels], dtype=self.dtype))
+    tf_result = tf.python.math_ops.add(tf_a, tf_b)
+
+    a = Tensor(data_layout=types_pb2.NC, tensor_data=tf_a.numpy())
+    b = Tensor(data_layout=types_pb2.NC, tensor_data=tf_b.numpy())
+    with Graph(name=self.graph_name, backend=self.backend) as graph:
+      math_ops.add(a, b)
+    self.runAndValidate(graph, tf_result)
+
+  def test_mul(self):
+    batch = 4
+    channels = 32
+    tf_a = tf.Variable(initializer(shape=[batch, channels], dtype=self.dtype))
+    tf_b = tf.Variable(initializer(shape=[batch, channels], dtype=self.dtype))
+    tf_result = tf.python.math_ops.mul(tf_a, tf_b)
+
+    a = Tensor(data_layout=types_pb2.NC, tensor_data=tf_a.numpy())
+    b = Tensor(data_layout=types_pb2.NC, tensor_data=tf_b.numpy())
+    with Graph(name=self.graph_name, backend=self.backend) as graph:
+      math_ops.mul(a, b)
+    self.runAndValidate(graph, tf_result)
+
+if __name__ == "__main__":
+  unittest.main()

--- a/smaug/python/ops/fp_precision_test.py
+++ b/smaug/python/ops/fp_precision_test.py
@@ -28,7 +28,7 @@ class FpPrecisionTest(SmaugTest):
     b = Tensor(data_layout=types_pb2.NC, tensor_data=tf_b.numpy())
     with Graph(name=self.graph_name, backend=self.backend) as graph:
       nn_ops.mat_mul(a, b)
-    self.runAndValidate(graph, tf_result)
+    self.runAndValidate(graph, tf_result, decimal=3)
 
   def test_convolution(self):
     batch = 4
@@ -54,7 +54,7 @@ class FpPrecisionTest(SmaugTest):
         tensor_data=np.transpose(tf_filters.numpy(), (3, 0, 1, 2)))
     with Graph(name=self.graph_name, backend=self.backend) as graph:
       nn_ops.convolution(inputs, filters, stride=[1, 1], padding="same")
-    self.runAndValidate(graph, tf_results)
+    self.runAndValidate(graph, tf_results, decimal=2)
 
   def test_add(self):
     batch = 4
@@ -67,7 +67,7 @@ class FpPrecisionTest(SmaugTest):
     b = Tensor(data_layout=types_pb2.NC, tensor_data=tf_b.numpy())
     with Graph(name=self.graph_name, backend=self.backend) as graph:
       math_ops.add(a, b)
-    self.runAndValidate(graph, tf_result)
+    self.runAndValidate(graph, tf_result, decimal=3)
 
   def test_mul(self):
     batch = 4
@@ -80,7 +80,7 @@ class FpPrecisionTest(SmaugTest):
     b = Tensor(data_layout=types_pb2.NC, tensor_data=tf_b.numpy())
     with Graph(name=self.graph_name, backend=self.backend) as graph:
       math_ops.mul(a, b)
-    self.runAndValidate(graph, tf_result)
+    self.runAndValidate(graph, tf_result, decimal=3)
 
 if __name__ == "__main__":
   unittest.main()

--- a/smaug/python/smaug_test.py
+++ b/smaug/python/smaug_test.py
@@ -54,7 +54,7 @@ class SmaugTest(unittest.TestCase):
 
     return returncode
 
-  def runAndValidate(self, graph, expected_output):
+  def runAndValidate(self, graph, expected_output, decimal=3):
     """ Run the test and validate the results. """
     os.chdir(self.run_dir)
     graph.write_graph()
@@ -82,4 +82,4 @@ class SmaugTest(unittest.TestCase):
       sg_output = sg_output_proto.data.int64_data
     shape = _account_for_padding(sg_output_proto.shape)
     sg_output = np.reshape(sg_output, sg_output_proto.shape.dims)
-    assert_array_almost_equal(expected_output, sg_output, decimal=2)
+    assert_array_almost_equal(expected_output, sg_output, decimal)

--- a/smaug/python/smaug_test.py
+++ b/smaug/python/smaug_test.py
@@ -82,4 +82,4 @@ class SmaugTest(unittest.TestCase):
       sg_output = sg_output_proto.data.int64_data
     shape = _account_for_padding(sg_output_proto.shape)
     sg_output = np.reshape(sg_output, sg_output_proto.shape.dims)
-    assert_array_almost_equal(expected_output, sg_output, decimal=3)
+    assert_array_almost_equal(expected_output, sg_output, decimal=2)


### PR DESCRIPTION
The way we model FP16 operations in Aladdin, which converts FP16 to FP32 for
computation and converts the results back to FP16 can potentially lead to
slight precision loss. The aggregated effect can lead to some tests failing
the required accuracy. This adds a test for all the precision-losing operators
against TF operators and also relaxes the required accuracy from 3 decimals to 2
decimals.

This fixes issue #11 .

TESTED=unit