### PR TITLE
smv: Forgot to untile the output tiles after running softmax.

### DIFF
--- a/smaug/operators/smv/smv_softmax_op.cpp
+++ b/smaug/operators/smv/smv_softmax_op.cpp
@@ -49,6 +49,11 @@ void SmvSoftmaxOp::run() {
                      smv::spad0, smv::spad1, inputShape[0], inputShape[1],
                      inputShape.getPadding(1));
     }
+    {
+        auto stats = gem5::ScopedStats(
+                stats::kTensorFinalStart, stats::kTensorFinalEnd);
+        outputs.untile();
+    }
 }
 
 }  // namespace smaug


### PR DESCRIPTION
After running all tiles, we need to shuffle the tiles to the original output
tensor.

TESTED=all tests are passing.