### PR TITLE
tests: Use 4 threads in CircleCI build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,8 @@ jobs:
       - run:
           name: Build
           command: |
-            make all -j2
-            make test -j2
+            make all -j4
+            make test -j4
       - run:
           name: Run unit tests
           command: |


### PR DESCRIPTION
The VCPU provided by CircleCI has 2 threads per core. This reduces the CI build
from 10 mins to 7 mins (the SMAUG build reduces to 3.5 mins from 6.5 mins).