### PR TITLE
python: Simplify Python module naming for easier usage.

### DIFF
--- a/smaug/__init__.py
+++ b/smaug/__init__.py
@@ -1,0 +1,10 @@
+from smaug.core.types_pb2 import *
+
+from smaug.python.ops import math_ops as math
+from smaug.python.ops import nn
+from smaug.python.ops.array_ops import *
+from smaug.python.ops.control_flow_ops import cond
+from smaug.python.ops.data_op import input_data
+
+from smaug.python.graph import Graph
+from smaug.python.tensor import Tensor

--- a/smaug/__init__.py
+++ b/smaug/__init__.py
@@ -1,8 +1,8 @@
 from smaug.core.types_pb2 import *
 
 from smaug.python.ops import math_ops as math
+from smaug.python.ops import array_ops as tensor
 from smaug.python.ops import nn
-from smaug.python.ops.array_ops import *
 from smaug.python.ops.control_flow_ops import cond
 from smaug.python.ops.data_op import input_data
 

--- a/smaug/python/create_model_example.py
+++ b/smaug/python/create_model_example.py
@@ -1,99 +1,87 @@
 #!/usr/bin/env python
-#
-# Examples for creating models.
-#
-# This file contains two examples of creating models for SMAUG.
-# create_residual_model() creates a basic residual unit, and
-# create_sequential_model() creates a small sequential model.
-#
-# Note that all the tensors and operators must be created within
-# a Graph context. The target backend is also specified via the
-# Graph context. See the below for examples. The user can get a
-# summary of the graph by calling print_summary(). To serialize
-# the graph into a pb file, call write_graph().
 
+"""Examples for creating models.
+
+This file contains two examples of creating models for SMAUG.
+create_residual_model() creates a basic residual unit, and
+create_sequential_model() creates a small sequential model.
+
+Note that all the tensors and operators must be created within
+a Graph context. The target backend is also specified via the
+Graph context. See the below for examples. The user can get a
+summary of the graph by calling print_summary(). To serialize
+the graph into a pb file, call write_graph().
+"""
 
 import numpy as np
-from smaug.core import types_pb2
-from smaug.python.graph import Graph
-from smaug.python.tensor import Tensor
-from smaug.python.ops import array_ops, math_ops, data_op, nn_ops
+import smaug as sg
 
 def create_residual_model():
-  with Graph(name="residual_graph", backend="SMV") as graph:
+  with sg.Graph(name="residual_graph", backend="SMV") as graph:
     # Tensors and kernels are initialized as NCHW layout.
-    input_tensor = Tensor(
+    input_tensor = sg.Tensor(
         tensor_data=np.random.rand(1, 1, 28, 28).astype(np.float16))
-    filter_tensor0 = Tensor(
+    filter_tensor0 = sg.Tensor(
         tensor_data=np.random.rand(64, 1, 3, 3).astype(np.float16))
-    filter_tensor1 = Tensor(
+    filter_tensor1 = sg.Tensor(
         tensor_data=np.random.rand(64, 1, 3, 3).astype(np.float16))
-    filter_tensor2 = Tensor(
+    filter_tensor2 = sg.Tensor(
         tensor_data=np.random.rand(64, 64, 3, 3).astype(np.float16))
-    bn_mean_tensor = Tensor(
-        data_layout=types_pb2.NC,
-        tensor_data=np.random.rand(1, 64).astype(np.float16))
-    bn_var_tensor = Tensor(
-        data_layout=types_pb2.NC,
-        tensor_data=np.random.rand(1, 64).astype(np.float16))
-    bn_gamma_tensor = Tensor(
-        data_layout=types_pb2.NC,
-        tensor_data=np.random.rand(1, 64).astype(np.float16))
-    bn_beta_tensor = Tensor(
-        data_layout=types_pb2.NC,
-        tensor_data=np.random.rand(1, 64).astype(np.float16))
+    bn_mean_tensor = sg.Tensor(
+        data_layout=sg.NC, tensor_data=np.random.rand(1, 64).astype(np.float16))
+    bn_var_tensor = sg.Tensor(
+        data_layout=sg.NC, tensor_data=np.random.rand(1, 64).astype(np.float16))
+    bn_gamma_tensor = sg.Tensor(
+        data_layout=sg.NC, tensor_data=np.random.rand(1, 64).astype(np.float16))
+    bn_beta_tensor = sg.Tensor(
+        data_layout=sg.NC, tensor_data=np.random.rand(1, 64).astype(np.float16))
 
-    act = data_op.input_data(input_tensor)
-    x = nn_ops.convolution(act, filter_tensor0, stride=[1, 1], padding="same")
-    out = nn_ops.convolution(act, filter_tensor1, stride=[1, 1], padding="same")
-    out = nn_ops.batch_norm(
+    act = sg.input_data(input_tensor)
+    x = sg.nn.convolution(act, filter_tensor0, stride=[1, 1], padding="same")
+    out = sg.nn.convolution(act, filter_tensor1, stride=[1, 1], padding="same")
+    out = sg.nn.batch_norm(
         out, bn_mean_tensor, bn_var_tensor, bn_gamma_tensor, bn_beta_tensor,
-        activation=types_pb2.ReLU)
-    out = nn_ops.convolution(out, filter_tensor2, stride=[1, 1], padding="same")
-    out = math_ops.add(x, out)
+        activation=sg.ReLU)
+    out = sg.nn.convolution(out, filter_tensor2, stride=[1, 1], padding="same")
+    out = sg.math.add(x, out)
 
     return graph
 
-
 def create_sequential_model():
-  with Graph(name="sequential_graph", backend="Reference") as graph:
+  with sg.Graph(name="sequential_graph", backend="Reference") as graph:
     # Tensors and weights are initialized as NCHW layout.
-    input_tensor = Tensor(
+    input_tensor = sg.Tensor(
         tensor_data=np.random.rand(1, 3, 32, 32).astype(np.float32))
-    filter_tensor0 = Tensor(
+    filter_tensor0 = sg.Tensor(
         tensor_data=np.random.rand(64, 3, 3, 3).astype(np.float32))
-    filter_tensor1 = Tensor(
+    filter_tensor1 = sg.Tensor(
         tensor_data=np.random.rand(64, 64, 3, 3).astype(np.float32))
-    weight_tensor0 = Tensor(
-        data_layout=types_pb2.NC,
-        tensor_data=np.random.rand(256, 16384).astype(np.float32))
-    weight_tensor1 = Tensor(
-        data_layout=types_pb2.NC,
-        tensor_data=np.random.rand(10, 256).astype(np.float32))
-    bn_mean_tensor = Tensor(
-        data_layout=types_pb2.NC,
-        tensor_data=np.random.rand(1, 64).astype(np.float32))
-    bn_var_tensor = Tensor(
-        data_layout=types_pb2.NC,
-        tensor_data=np.random.rand(1, 64).astype(np.float32))
-    bn_gamma_tensor = Tensor(
-        data_layout=types_pb2.NC,
-        tensor_data=np.random.rand(1, 64).astype(np.float32))
-    bn_beta_tensor = Tensor(
-        data_layout=types_pb2.NC,
-        tensor_data=np.random.rand(1, 64).astype(np.float32))
+    weight_tensor0 = sg.Tensor(
+        data_layout=sg.NC, tensor_data=np.random.rand(256,
+                                                      16384).astype(np.float32))
+    weight_tensor1 = sg.Tensor(
+        data_layout=sg.NC, tensor_data=np.random.rand(10,
+                                                      256).astype(np.float32))
+    bn_mean_tensor = sg.Tensor(
+        data_layout=sg.NC, tensor_data=np.random.rand(1, 64).astype(np.float32))
+    bn_var_tensor = sg.Tensor(
+        data_layout=sg.NC, tensor_data=np.random.rand(1, 64).astype(np.float32))
+    bn_gamma_tensor = sg.Tensor(
+        data_layout=sg.NC, tensor_data=np.random.rand(1, 64).astype(np.float32))
+    bn_beta_tensor = sg.Tensor(
+        data_layout=sg.NC, tensor_data=np.random.rand(1, 64).astype(np.float32))
 
-    out = data_op.input_data(input_tensor)
-    out = nn_ops.convolution(
-        out, filter_tensor0, stride=[1, 1], padding="same", activation=types_pb2.ReLU)
-    out = nn_ops.batch_norm(
+    out = sg.input_data(input_tensor)
+    out = sg.nn.convolution(
+        out, filter_tensor0, stride=[1, 1], padding="same", activation=sg.ReLU)
+    out = sg.nn.batch_norm(
         out, bn_mean_tensor, bn_var_tensor, bn_gamma_tensor, bn_beta_tensor)
-    out = nn_ops.convolution(
-        out, filter_tensor1, stride=[1, 1], padding="same", activation=types_pb2.ReLU)
-    out = nn_ops.max_pool(out, pool_size=[2, 2], stride=[2, 2])
-    out = array_ops.flatten(out)
-    out = nn_ops.mat_mul(out, weight_tensor0, activation=types_pb2.ReLU)
-    out = nn_ops.mat_mul(out, weight_tensor1)
+    out = sg.nn.convolution(
+        out, filter_tensor1, stride=[1, 1], padding="same", activation=sg.ReLU)
+    out = sg.nn.max_pool(out, pool_size=[2, 2], stride=[2, 2])
+    out = sg.flatten(out)
+    out = sg.nn.mat_mul(out, weight_tensor0, activation=sg.ReLU)
+    out = sg.nn.mat_mul(out, weight_tensor1)
 
     return graph
 

--- a/smaug/python/create_model_example.py
+++ b/smaug/python/create_model_example.py
@@ -41,7 +41,7 @@ def create_residual_model():
     out = sg.nn.convolution(act, filter_tensor1, stride=[1, 1], padding="same")
     out = sg.nn.batch_norm(
         out, bn_mean_tensor, bn_var_tensor, bn_gamma_tensor, bn_beta_tensor,
-        activation=sg.ReLU)
+        activation="relu")
     out = sg.nn.convolution(out, filter_tensor2, stride=[1, 1], padding="same")
     out = sg.math.add(x, out)
 
@@ -73,14 +73,14 @@ def create_sequential_model():
 
     out = sg.input_data(input_tensor)
     out = sg.nn.convolution(
-        out, filter_tensor0, stride=[1, 1], padding="same", activation=sg.ReLU)
+        out, filter_tensor0, stride=[1, 1], padding="same", activation="relu")
     out = sg.nn.batch_norm(
         out, bn_mean_tensor, bn_var_tensor, bn_gamma_tensor, bn_beta_tensor)
     out = sg.nn.convolution(
-        out, filter_tensor1, stride=[1, 1], padding="same", activation=sg.ReLU)
+        out, filter_tensor1, stride=[1, 1], padding="same", activation="relu")
     out = sg.nn.max_pool(out, pool_size=[2, 2], stride=[2, 2])
     out = sg.flatten(out)
-    out = sg.nn.mat_mul(out, weight_tensor0, activation=sg.ReLU)
+    out = sg.nn.mat_mul(out, weight_tensor0, activation="relu")
     out = sg.nn.mat_mul(out, weight_tensor1)
 
     return graph

--- a/smaug/python/create_model_example.py
+++ b/smaug/python/create_model_example.py
@@ -79,7 +79,7 @@ def create_sequential_model():
     out = sg.nn.convolution(
         out, filter_tensor1, stride=[1, 1], padding="same", activation="relu")
     out = sg.nn.max_pool(out, pool_size=[2, 2], stride=[2, 2])
-    out = sg.flatten(out)
+    out = sg.tensor.flatten(out)
     out = sg.nn.mat_mul(out, weight_tensor0, activation="relu")
     out = sg.nn.mat_mul(out, weight_tensor1)
 

--- a/smaug/python/global_vars.py
+++ b/smaug/python/global_vars.py
@@ -5,7 +5,6 @@ Currently it contains:
   2) Alignment information for various backends.
   3) Input/output layouts for operators of various backends.
   4) Supported data types of backends.
-  5) Supported activation functions.
 """
 
 import numpy as np
@@ -80,7 +79,3 @@ backend_layouts = {
 }
 
 backend_datatype = {"SMV": np.float16, "Reference": np.float32}
-
-supported_activations = [
-    ReLU, LReLU, ELU, SELU, Tanh, HardTanh, Sigmoid, Softmax
-]

--- a/smaug/python/ops/activation_ops.py
+++ b/smaug/python/ops/activation_ops.py
@@ -3,33 +3,16 @@ from smaug.core import node_pb2
 from smaug.python import global_vars
 from smaug.python.ops import common
 
-def _get_activation_type(activation):
-  """Return the corresponding activation type.
-
-  Args:
-    activation: A string.
-
-  Returns:
-    An activation op type such as `types_pb2.ReLU`.
-  """
-  if activation == "relu":
-    return types_pb2.ReLU
-  elif activation == "lrelu":
-    return types_pb2.LReLU
-  elif activation == "elu":
-    return types_pb2.ELU
-  elif activation == "selu":
-    return types_pb2.SELU
-  elif activation == "tanh":
-    return types_pb2.Tanh
-  elif activation == "hard_tanh":
-    return types_pb2.HardTanh
-  elif activation == "sigmoid":
-    return types_pb2.Sigmoid
-  elif activation == "softmax":
-    return types_pb2.Softmax
-  else:
-    raise ValueError("%s is not a supported activation function!" % activation)
+_activation_types = {
+    "relu": types_pb2.ReLU,
+    "lrelu": types_pb2.LReLU,
+    "elu": types_pb2.ELU,
+    "selu": types_pb2.SELU,
+    "tanh": types_pb2.Tanh,
+    "hard_tanh": types_pb2.HardTanh,
+    "sigmoid": types_pb2.Sigmoid,
+    "softmax": types_pb2.Softmax
+}
 
 def _set_activation_params(activation, params, proto):
   """Set the parameters of the activation function.
@@ -69,7 +52,7 @@ def get_activation_op(activation):
   Args:
     activation: A string representing the activation function.
   """
-  op_type = _get_activation_type(activation)
+  op_type = _activation_types[activation]
   if op_type == types_pb2.ReLU:
     return relu
   elif op_type == types_pb2.LReLU:
@@ -87,19 +70,22 @@ def get_activation_op(activation):
   elif op_type == types_pb2.Softmax:
     return softmax
 
-def to_proto(activation, params, proto):
-  """Set the activation proto.
+def to_proto(activation, params):
+  """Return the activation proto.
 
   Args:
     activation: A string representing the activation function.
     params: kwargs for the activation function parameters.
     proto: An `ActivationParams`, the proto to set.
+
+  Returns:
+    An `ActivationParams`, the proto.
   """
-  if activation is None:
-    return
-  act_type = _get_activation_type(activation)
+  proto = node_pb2.ActivationParams()
+  act_type = _activation_types[activation]
   proto.activation = act_type
   _set_activation_params(act_type, params, proto)
+  return proto
 
 def relu(input_tensor, name="relu"):
   return common.add_node(

--- a/smaug/python/ops/activation_ops.py
+++ b/smaug/python/ops/activation_ops.py
@@ -3,17 +3,6 @@ from smaug.core import node_pb2
 from smaug.python import global_vars
 from smaug.python.ops import common
 
-_activation_types = {
-    "relu": types_pb2.ReLU,
-    "lrelu": types_pb2.LReLU,
-    "elu": types_pb2.ELU,
-    "selu": types_pb2.SELU,
-    "tanh": types_pb2.Tanh,
-    "hard_tanh": types_pb2.HardTanh,
-    "sigmoid": types_pb2.Sigmoid,
-    "softmax": types_pb2.Softmax
-}
-
 def _set_activation_params(activation, params, proto):
   """Set the parameters of the activation function.
 
@@ -52,23 +41,7 @@ def get_activation_op(activation):
   Args:
     activation: A string representing the activation function.
   """
-  op_type = _activation_types[activation]
-  if op_type == types_pb2.ReLU:
-    return relu
-  elif op_type == types_pb2.LReLU:
-    return lrelu
-  elif op_type == types_pb2.ELU:
-    return elu
-  elif op_type == types_pb2.SELU:
-    return selu
-  elif op_type == types_pb2.Tanh:
-    return tanh
-  elif op_type == types_pb2.HardTanh:
-    return hard_tanh
-  elif op_type == types_pb2.Sigmoid:
-    return sigmoid
-  elif op_type == types_pb2.Softmax:
-    return softmax
+  return _activation_type_op_tuples[activation][1]
 
 def to_proto(activation, params):
   """Return the activation proto.
@@ -82,7 +55,7 @@ def to_proto(activation, params):
     An `ActivationParams`, the proto.
   """
   proto = node_pb2.ActivationParams()
-  act_type = _activation_types[activation]
+  act_type = _activation_type_op_tuples[activation][0]
   proto.activation = act_type
   _set_activation_params(act_type, params, proto)
   return proto
@@ -146,3 +119,14 @@ def softmax(input_tensor, name=None):
       name=name, op=types_pb2.Softmax, input_tensors=[input_tensor],
       output_tensors_dims=[input_tensor.shape.dims],
       output_tensor_layout=input_tensor.shape.layout)[0]
+
+_activation_type_op_tuples = {
+    "relu": (types_pb2.ReLU, relu),
+    "lrelu": (types_pb2.LReLU, lrelu),
+    "elu": (types_pb2.ELU, elu),
+    "selu": (types_pb2.SELU, selu),
+    "tanh": (types_pb2.Tanh, tanh),
+    "hard_tanh": (types_pb2.HardTanh, hard_tanh),
+    "sigmoid": (types_pb2.Sigmoid, sigmoid),
+    "softmax": (types_pb2.Softmax, softmax)
+}

--- a/smaug/python/ops/activation_ops_test.py
+++ b/smaug/python/ops/activation_ops_test.py
@@ -102,34 +102,50 @@ class ActivationFunctionTest(unittest.TestCase):
           act, filter_tensor, stride=[1, 1], padding="same", activation=None,
           name="conv_none")
       act = nn_ops.convolution(
-          act, filter_tensor, stride=[1, 1], padding="same",
-          activation=types_pb2.ReLU, name="conv_relu")
+          act, filter_tensor, stride=[1, 1], padding="same", activation="relu",
+          name="conv_relu")
+      act = nn_ops.convolution(
+          act, filter_tensor, stride=[1, 1], padding="same", activation="lrelu",
+          name="conv_lrelu")
+      act = nn_ops.convolution(
+          act, filter_tensor, stride=[1, 1], padding="same", activation="elu",
+          name="conv_elu")
+      act = nn_ops.convolution(
+          act, filter_tensor, stride=[1, 1], padding="same", activation="selu",
+          name="conv_selu")
+      act = nn_ops.convolution(
+          act, filter_tensor, stride=[1, 1], padding="same", activation="tanh",
+          name="conv_tanh")
       act = nn_ops.convolution(
           act, filter_tensor, stride=[1, 1], padding="same",
-          activation=types_pb2.LReLU, name="conv_lrelu")
+          activation="hard_tanh", name="conv_hard_tanh")
       act = nn_ops.convolution(
           act, filter_tensor, stride=[1, 1], padding="same",
-          activation=types_pb2.ELU, name="conv_elu")
+          activation="sigmoid", name="conv_sigmoid")
       act = nn_ops.convolution(
           act, filter_tensor, stride=[1, 1], padding="same",
-          activation=types_pb2.SELU, name="conv_selu")
-      act = nn_ops.convolution(
-          act, filter_tensor, stride=[1, 1], padding="same",
-          activation=types_pb2.Tanh, name="conv_tanh")
-      act = nn_ops.convolution(
-          act, filter_tensor, stride=[1, 1], padding="same",
-          activation=types_pb2.HardTanh, name="conv_hard_tanh")
-      act = nn_ops.convolution(
-          act, filter_tensor, stride=[1, 1], padding="same",
-          activation=types_pb2.Sigmoid, name="conv_sigmoid")
-      act = nn_ops.convolution(
-          act, filter_tensor, stride=[1, 1], padding="same",
-          activation=types_pb2.Softmax, name="conv_softmax")
+          activation="softmax", name="conv_softmax")
       act = nn_ops.batch_norm(
           act, bn_mean_tensor, bn_var_tensor, bn_gamma_tensor, bn_beta_tensor,
-          activation=types_pb2.ReLU, name="bn_relu")
-      act = nn_ops.mat_mul(
-          act, weight_tensor, activation=types_pb2.ReLU, name="fc_relu")
+          activation="relu", name="bn_relu")
+      out = nn_ops.mat_mul(
+          act, weight_tensor, activation="relu", name="fc_relu")
+      out = nn_ops.mat_mul(
+          act, weight_tensor, activation="lrelu",
+          activation_params={"slope": 0.1}, name="fc_lrelu")
+      out = nn_ops.mat_mul(
+          act, weight_tensor, activation="elu",
+          activation_params={"alpha": 0.3}, name="fc_elu")
+      out = nn_ops.mat_mul(
+          act, weight_tensor, activation="selu", activation_params={
+              "alpha": 1.0,
+              "lambda_param": 1.0
+          }, name="fc_selu")
+      out = nn_ops.mat_mul(
+          act, weight_tensor, activation="hard_tanh", activation_params={
+              "min": -2.0,
+              "max": 2.0
+          }, name="fc_hard_tanh")
     graph_proto, _ = test_graph.to_proto()
     # None
     node = get_node_proto(graph_proto, "conv_none")
@@ -170,6 +186,20 @@ class ActivationFunctionTest(unittest.TestCase):
     self.assertEqual(node.params.act_params.activation, types_pb2.ReLU)
     node = get_node_proto(graph_proto, "fc_relu")
     self.assertEqual(node.params.act_params.activation, types_pb2.ReLU)
+    node = get_node_proto(graph_proto, "fc_lrelu")
+    self.assertEqual(node.params.act_params.activation, types_pb2.LReLU)
+    self.assertAlmostEqual(node.params.act_params.lrelu_params.slope, 0.1)
+    node = get_node_proto(graph_proto, "fc_elu")
+    self.assertEqual(node.params.act_params.activation, types_pb2.ELU)
+    self.assertAlmostEqual(node.params.act_params.elu_params.alpha, 0.3)
+    node = get_node_proto(graph_proto, "fc_selu")
+    self.assertEqual(node.params.act_params.activation, types_pb2.SELU)
+    self.assertAlmostEqual(node.params.act_params.elu_params.alpha, 1.0)
+    self.assertAlmostEqual(node.params.act_params.elu_params.lambda_param, 1.0)
+    node = get_node_proto(graph_proto, "fc_hard_tanh")
+    self.assertEqual(node.params.act_params.activation, types_pb2.HardTanh)
+    self.assertAlmostEqual(node.params.act_params.hard_tanh_params.min, -2.0)
+    self.assertAlmostEqual(node.params.act_params.hard_tanh_params.max, 2.0)
 
 if __name__ == "__main__":
   unittest.main()

--- a/smaug/python/ops/nn.py
+++ b/smaug/python/ops/nn.py
@@ -1,0 +1,4 @@
+from smaug.python.ops.nn_ops import *
+from smaug.python.ops.activation_ops import *
+from smaug.python.ops.recurrent import *
+from smaug.python.ops.attention import *

--- a/smaug/python/ops/nn_ops.py
+++ b/smaug/python/ops/nn_ops.py
@@ -56,11 +56,7 @@ def convolution(
   params = node_pb2.Params()
   params.conv_params.padding = to_padding_type(padding)
   params.conv_params.stride.extend(stride)
-  if activation != None:
-    params.act_params.activation = activation
-    activation_ops.set_activation_params(
-        activation, params.act_params, activation_params)
-
+  activation_ops.to_proto(activation, activation_params, params.act_params)
   return common.add_node(
       name=name, op=types_pb2.Convolution3d,
       input_tensors=[input_tensor, filter_tensor],
@@ -88,10 +84,7 @@ def batch_norm(
   output_layout = types_pb2.UnknownLayout
   output_layout = types_pb2.NC if post_fc else input_tensor.shape.layout
   params = node_pb2.Params()
-  if activation != None:
-    params.act_params.activation = activation
-    activation_ops.set_activation_params(
-        activation, params.act_params, activation_params)
+  activation_ops.to_proto(activation, activation_params, params.act_params)
   return common.add_node(
       name=name, op=types_pb2.BatchNorm, input_tensors=[
           input_tensor, mean_tensor, var_tensor, gamma_tensor, beta_tensor
@@ -147,10 +140,7 @@ def mat_mul(
       input_tensor.shape.dims[0], weight_tensor.shape.dims[neuronIdx]
   ]
   params = node_pb2.Params()
-  if activation != None:
-    params.act_params.activation = activation
-    activation_ops.set_activation_params(
-        activation, params.act_params, activation_params)
+  activation_ops.to_proto(activation, activation_params, params.act_params)
   return common.add_node(
       name=name, op=types_pb2.InnerProduct,
       input_tensors=[input_tensor, weight_tensor],

--- a/smaug/python/ops/nn_ops.py
+++ b/smaug/python/ops/nn_ops.py
@@ -56,7 +56,9 @@ def convolution(
   params = node_pb2.Params()
   params.conv_params.padding = to_padding_type(padding)
   params.conv_params.stride.extend(stride)
-  activation_ops.to_proto(activation, activation_params, params.act_params)
+  if activation is not None:
+    params.act_params.CopyFrom(
+        activation_ops.to_proto(activation, activation_params))
   return common.add_node(
       name=name, op=types_pb2.Convolution3d,
       input_tensors=[input_tensor, filter_tensor],
@@ -84,7 +86,9 @@ def batch_norm(
   output_layout = types_pb2.UnknownLayout
   output_layout = types_pb2.NC if post_fc else input_tensor.shape.layout
   params = node_pb2.Params()
-  activation_ops.to_proto(activation, activation_params, params.act_params)
+  if activation is not None:
+    params.act_params.CopyFrom(
+        activation_ops.to_proto(activation, activation_params))
   return common.add_node(
       name=name, op=types_pb2.BatchNorm, input_tensors=[
           input_tensor, mean_tensor, var_tensor, gamma_tensor, beta_tensor
@@ -140,7 +144,9 @@ def mat_mul(
       input_tensor.shape.dims[0], weight_tensor.shape.dims[neuronIdx]
   ]
   params = node_pb2.Params()
-  activation_ops.to_proto(activation, activation_params, params.act_params)
+  if activation is not None:
+    params.act_params.CopyFrom(
+        activation_ops.to_proto(activation, activation_params))
   return common.add_node(
       name=name, op=types_pb2.InnerProduct,
       input_tensors=[input_tensor, weight_tensor],

--- a/smaug/python/ops/recurrent.py
+++ b/smaug/python/ops/recurrent.py
@@ -9,12 +9,12 @@ from smaug.python.ops import activation_ops
 
 class LSTM:
   def __init__(
-      self, weight_tensors, activation=types_pb2.Tanh, activation_params=dict(),
+      self, weight_tensors, activation="tanh", activation_params=dict(),
       name="lstm"):
     """ An LSTM layer.
 
     Args:
-      weight_tensors: A list of four weights.
+      weight_tensors: A list of two weights.
       activation: Activation function used in LSTM.
       activation_params: kwargs for the activation function.
     """
@@ -22,7 +22,7 @@ class LSTM:
     self.name = name + ":"
     self.kernel, self.recurrent_kernel = weight_tensors
     self.prepare_states()
-    self.activation = activation_ops.activation(activation)
+    self.activation = activation_ops.get_activation_op(activation)
     self.activation_params = activation_params
 
   def prepare_states(self):
@@ -120,7 +120,7 @@ class LSTM:
 
 class BidirectionalLSTM:
   def __init__(
-      self, fwd_weight_tensors, bwd_weight_tensors, activation=types_pb2.Tanh,
+      self, fwd_weight_tensors, bwd_weight_tensors, activation="tanh",
       activation_params=dict(), name="bidir_lstm"):
     """ A bidirectional LSTM layer.
 


### PR DESCRIPTION
This makes the Python API easier to use. For example, previously the Python code
looks like:

```python
import numpy as np
from smaug.python.ops import array_ops, data_op, math_ops, nn_ops
from smaug.python.tensor import Tensor
from smaug.python.graph import Graph
from smaug.core import types_pb2

with Graph():
  x = Tensor(layout=types_pb2.NC, tensor_data=np.array())
  x = data_op.input_data(x)
  y = math_ops.add(x, x)
  z = array_ops.flatten(y)
  u = nn_ops.matmul(..., activation=types_pb2.ReLU)
```
Now it becomes:

```python
import numpy as np
import smaug as sg

with sg.Graph():
  x = sg.Tensor(layout=sg.NC, tensor_data=np.array())
  x = sg.input_data(x)
  y = sg.math.add(x, x)
  z = sg.flatten(y)
  u = sg.nn.matmul(..., activation=sg.ReLU)
```

This fixes issue #31.