### PR TITLE
make: Generate proto files directly into the build dir.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - image: xyzsam/smaug:latest
 
     environment:
-      SMAUG_HOME: /root/project
+      SMAUG_HOME: /root/project/smaug
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - image: xyzsam/smaug:latest
 
     environment:
-      SMAUG_HOME: /root/project/smaug
+      SMAUG_HOME: /root/project
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       - run:
           name: Run unit tests
           command: |
-            export PYTHONPATH=$SMAUG_HOME:$PYTHONPATH
+            export PYTHONPATH=$SMAUG_HOME/build:$PYTHONPATH
             make test-run
       - run:
           name: Download latest gem5-aladdin binary

--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -149,6 +149,7 @@ BUILD_DIR = build
 PROTO_PY_SRCS = $(patsubst %.proto, %_pb2.py, $(PROTO_SRCS))
 PROTO_CPP_SRCS = $(patsubst %.proto, %.pb.cpp, $(PROTO_SRCS))
 BUILD_PROTO_CPP_SRCS = $(patsubst %, $(BUILD_DIR)/%, $(PROTO_CPP_SRCS))
+BUILD_PROTO_PY_SRCS = $(patsubst %, $(BUILD_DIR)/%, $(PROTO_PY_SRCS))
 
 # Create a build directory that just has symlinks to all the source files, so
 # we can build everything seemingly "alongside" the source.
@@ -161,12 +162,12 @@ src-symlinks:
 	@$(foreach f, $(GEM5_SRCS), cp -asf $(ALADDIN_HOME)/$(f) $(BUILD_DIR)/gem5/$(notdir $(f));)
 	@mkdir -p $(BUILD_DIR)/bin
 
-protos: $(BUILD_PROTO_CPP_SRCS) $(PROTO_PY_SRCS)
+protos: $(BUILD_PROTO_CPP_SRCS) $(BUILD_PROTO_PY_SRCS)
 
 $(BUILD_DIR)/%.pb.cpp: %.proto
 	$(PROTOC) -I=$(SMAUG_HOME) --cpp_out=. $^
 	mv $(basename $^).pb.cc $@
 	mv $(basename $^).pb.h $(dir $@)
 
-%_pb2.py: %.proto
-	$(PROTOC) -I=$(SMAUG_HOME) --python_out=. $^
+$(BUILD_DIR)/%_pb2.py: %.proto
+	$(PROTOC) -I=$(SMAUG_HOME) --python_out=$(BUILD_DIR) $^

--- a/make/Makefile.native
+++ b/make/Makefile.native
@@ -60,7 +60,7 @@ BUILD_PY_TESTS = $(patsubst %, $(BUILD_DIR)/%, $(PY_TESTS))
 
 TEST_OBJ = $(patsubst %.cpp, %.o, $(BUILD_TESTS))
 TEST_BIN = $(patsubst %.cpp, %, $(BUILD_TESTS))
-ALL_TESTS = $(realpath $(TEST_BIN) $(BUILD_PY_TESTS))
+ALL_TESTS = $(abspath $(TEST_BIN) $(BUILD_PY_TESTS))
 
 tests:
 	@$(MAKE) -f make/Makefile.common --no-print-directory src-symlinks

--- a/make/Makefile.native
+++ b/make/Makefile.native
@@ -98,5 +98,5 @@ run-tests:
 ###########################
 
 clean:
-	rm -f $(BUILD_DIR)/bin/$(EXEC) $(TEST_BIN) $(BUILD_PROTO_CPP_SRCS) $(PROTO_PY_SRCS)
+	rm -f $(BUILD_DIR)/bin/$(EXEC) $(TEST_BIN) $(BUILD_PROTO_CPP_SRCS) $(BUILD_PROTO_PY_SRCS) $(PROTO_PY_SRCS)
 	find $(BUILD_DIR) -name "*.o" | xargs rm -f

--- a/make/Makefile.native
+++ b/make/Makefile.native
@@ -60,7 +60,7 @@ BUILD_PY_TESTS = $(patsubst %, $(BUILD_DIR)/%, $(PY_TESTS))
 
 TEST_OBJ = $(patsubst %.cpp, %.o, $(BUILD_TESTS))
 TEST_BIN = $(patsubst %.cpp, %, $(BUILD_TESTS))
-ALL_TESTS = $(TEST_BIN) $(BUILD_PY_TESTS)
+ALL_TESTS = $(realpath $(TEST_BIN) $(BUILD_PY_TESTS))
 
 tests:
 	@$(MAKE) -f make/Makefile.common --no-print-directory src-symlinks
@@ -76,9 +76,10 @@ run-tests:
 	@$(MAKE) -f make/Makefile.native --no-print-directory tests
 	@$(MAKE) -f make/Makefile.native --no-print-directory exec
 	@HAS_ERROR=0;				\
+	cd $(BUILD_DIR); \
 	for t in $(ALL_TESTS); do 		\
 		printf "Running test ($$t)";	\
-		./$$t > tmpout 2>&1;		\
+		$$t > tmpout 2>&1;		\
 		RET_VAL=$$(echo $$?);		\
 		if [ $$RET_VAL -ne 0 ]; then 	\
 			echo "... failed";	\

--- a/smaug/core/datatypes.h
+++ b/smaug/core/datatypes.h
@@ -7,40 +7,6 @@
 
 namespace smaug {
 
-class DataLayoutSet {
-  public:
-    // DataLayoutSet(DataLayout layout) : layouts(layout) {}
-    DataLayoutSet(int bitmask = 0) : layouts(bitmask) {}
-
-    void insert(DataLayout layout) { layouts |= layout; }
-    void remove(DataLayout layout) { layouts &= (~layout); }
-    bool contains(DataLayout layout) const { return layouts & (int)layout; }
-    bool overlapsWith(const DataLayoutSet& other) const {
-        return (layouts & other.layouts) != 0;
-    }
-    int getLayouts() const { return layouts; }
-    bool operator==(const DataLayoutSet& other) const {
-        return layouts == other.layouts;
-    }
-    bool operator<(const DataLayoutSet& other) const {
-        return layouts < other.layouts;
-    }
-    std::vector<DataLayout> toArray() const {
-        int mask = DataLayout::EndDataLayout;
-        std::vector<DataLayout> array;
-        while (mask > 0) {
-            int match = layouts & mask;
-            if (match)
-                array.push_back((DataLayout)mask);
-            mask >>= 1;
-        }
-        return array;
-    }
-
-   protected:
-    int layouts;
-};
-
 using float16 = uint16_t;
 
 template <typename T>


### PR DESCRIPTION
Currently, these files were being generated directly into the source
code tree itself, which is not the right place for generated code.