### PR TITLE
Exclude Python and SMAUGv1 code from Doxygen.

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -855,7 +855,6 @@ FILE_PATTERNS          = *.c \
                          *.cc \
                          *.cpp \
                          *.h \
-                         *.py \
                          *.dox
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
@@ -871,7 +870,10 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                =
+EXCLUDE                = smaug/operators/smiv \
+                         smaug/utility/compression.h \
+                         smaug/utility/compression.c \
+                         nnet_fwd_defs.h
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -887,7 +889,9 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       =
+EXCLUDE_PATTERNS       = smaug/operators/smiv/* \
+                         smaug/utility/compression* \
+                         nnet_fwd_defs.h
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION
We're planning to use Sphinx to generate Python docs.