### PR TITLE
Remove git-diff detection logic.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,15 +72,12 @@ jobs:
             mkdir -p docs
             cp -rf /tmp/smaug_docs_out/html/* docs/
             git add docs/
-            git diff HEAD --exit-code > /dev/null
-            HASCHANGES=$?
-            if [[ $HASCHANGES -eq 0 ]]; then
-              echo "No changes to documentation, exiting."
-              exit 0
-            fi
             git config --global user.name "CircleCI Docs Deploy"
             git config --global user.email "no@email.addr"
-            git commit -a -m "Update documentation on ${CIRCLE_BRANCH} for commit ${CIRCLE_SHA1}"
+            # If there are no differences, git commit returns exit code 1,
+            # which we have to swallow to prevent the job from failing.
+            git commit -a -m "Update documentation on ${CIRCLE_BRANCH} for commit ${CIRCLE_SHA1}" || true
+            # This will return exit code 0 even if there are no new commits.
             git push origin master
 
 workflows:


### PR DESCRIPTION
CircleCI runs all its bash commands with -eo pipefail, so any command
that returns a non-zero exit code will cause the job to fail. In this
case, git-diff will return 1 if there are diffs. The solution is to
ignore git-diff and just create a commit, swallowing the exit code
(which is 1 if there are no diffs). If there is no diff, there will be
no commit, but git push will still return 0.