### PR TITLE
Cleanup Doxygen/Sphinx/Breathe/Exhale warnings

### DIFF
--- a/docs/source/Doxyfile
+++ b/docs/source/Doxyfile
@@ -170,7 +170,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        =
+STRIP_FROM_PATH        = $(SMAUG_HOME)
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -2184,7 +2184,8 @@ PREDEFINED             = __attribute__(x)= \
 # definition found in the source code.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_AS_DEFINED      =
+EXPAND_AS_DEFINED      = DECL_CREATE_OP \
+                         DECL_CREATE_SMV_OP
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
 # remove all references to function-like macros that are alone on a line, have

--- a/docs/source/Doxyfile
+++ b/docs/source/Doxyfile
@@ -870,10 +870,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = smaug/operators/smiv \
-                         smaug/utility/compression.h \
-                         smaug/utility/compression.c \
-                         nnet_fwd_defs.h
+EXCLUDE                =
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -889,9 +886,10 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = smaug/operators/smiv/* \
-                         smaug/utility/compression* \
-                         nnet_fwd_defs.h
+EXCLUDE_PATTERNS       = *smiv* \
+                         */compression* \
+                         */*_test.cpp \
+                         */nnet_fwd_defs.h
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the
@@ -2174,8 +2172,7 @@ PREDEFINED             = __attribute__(x)= \
                          __GNUC__ \
                          ALWAYS_INLINE \
                          ASSERT \
-                         ASSUME_ALIGNED \
-                         REGISTER_SPECIAL_OP
+                         ASSUME_ALIGNED
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/docs/source/DoxygenLayout.xml
+++ b/docs/source/DoxygenLayout.xml
@@ -9,25 +9,11 @@
       <tab type="namespacelist" visible="yes" title="" intro=""/>
       <tab type="namespacemembers" visible="yes" title="" intro=""/>
     </tab>
-    <tab type="interfaces" visible="yes" title="">
-      <tab type="interfacelist" visible="yes" title="" intro=""/>
-      <tab type="interfaceindex" visible="$ALPHABETICAL_INDEX" title=""/>
-      <tab type="interfacehierarchy" visible="yes" title="" intro=""/>
-    </tab>
     <tab type="classes" visible="yes" title="">
       <tab type="classlist" visible="yes" title="" intro=""/>
       <tab type="classindex" visible="$ALPHABETICAL_INDEX" title=""/>
       <tab type="hierarchy" visible="yes" title="" intro=""/>
       <tab type="classmembers" visible="yes" title="" intro=""/>
-    </tab>
-    <tab type="structs" visible="yes" title="">
-      <tab type="structlist" visible="yes" title="" intro=""/>
-      <tab type="structindex" visible="$ALPHABETICAL_INDEX" title=""/>
-    </tab>
-    <tab type="exceptions" visible="yes" title="">
-      <tab type="exceptionlist" visible="yes" title="" intro=""/>
-      <tab type="exceptionindex" visible="$ALPHABETICAL_INDEX" title=""/>
-      <tab type="exceptionhierarchy" visible="yes" title="" intro=""/>
     </tab>
     <tab type="files" visible="yes" title="">
       <tab type="filelist" visible="yes" title="" intro=""/>
@@ -101,13 +87,8 @@
     <memberdecl>
       <nestednamespaces visible="yes" title=""/>
       <constantgroups visible="yes" title=""/>
-      <interfaces visible="yes" title=""/>
       <classes visible="yes" title=""/>
-      <structs visible="yes" title=""/>
-      <exceptions visible="yes" title=""/>
       <typedefs title=""/>
-      <sequences title=""/>
-      <dictionaries title=""/>
       <enums title=""/>
       <functions title=""/>
       <variables title=""/>
@@ -117,8 +98,6 @@
     <memberdef>
       <inlineclasses title=""/>
       <typedefs title=""/>
-      <sequences title=""/>
-      <dictionaries title=""/>
       <enums title=""/>
       <functions title=""/>
       <variables title=""/>
@@ -134,16 +113,11 @@
     <includedbygraph visible="$INCLUDED_BY_GRAPH"/>
     <sourcelink visible="yes"/>
     <memberdecl>
-      <interfaces visible="yes" title=""/>
       <classes visible="yes" title=""/>
-      <structs visible="yes" title=""/>
-      <exceptions visible="yes" title=""/>
       <namespaces visible="yes" title=""/>
       <constantgroups visible="yes" title=""/>
       <defines title=""/>
       <typedefs title=""/>
-      <sequences title=""/>
-      <dictionaries title=""/>
       <enums title=""/>
       <functions title=""/>
       <variables title=""/>
@@ -154,8 +128,6 @@
       <inlineclasses title=""/>
       <defines title=""/>
       <typedefs title=""/>
-      <sequences title=""/>
-      <dictionaries title=""/>
       <enums title=""/>
       <functions title=""/>
       <variables title=""/>
@@ -175,8 +147,6 @@
       <classes visible="yes" title=""/>
       <defines title=""/>
       <typedefs title=""/>
-      <sequences title=""/>
-      <dictionaries title=""/>
       <enums title=""/>
       <enumvalues title=""/>
       <functions title=""/>
@@ -196,8 +166,6 @@
       <inlineclasses title=""/>
       <defines title=""/>
       <typedefs title=""/>
-      <sequences title=""/>
-      <dictionaries title=""/>
       <enums title=""/>
       <enumvalues title=""/>
       <functions title=""/>

--- a/docs/source/operators.dox
+++ b/docs/source/operators.dox
@@ -1,10 +1,10 @@
-/** \defgroup Operators
+/** \defgroup Operators All SMAUG Operators
   *
   * All operators supported by SMAUG.
   */
 
 /**
-  * \defgroup AladdinKernels
+  * \defgroup AladdinKernels Aladdin Kernel Functions
   *
   * Kernel functions meant to be run under Aladdin.
   */

--- a/smaug/core/backend.h
+++ b/smaug/core/backend.h
@@ -28,6 +28,7 @@ enum BackendName {
     UnknownBackend,
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 class Workspace;
 template <typename Backend> class ConvolutionOp;
 template <typename Backend> class DataOp;
@@ -57,6 +58,7 @@ template <typename Backend> class EluOp;
 template <typename Backend> class SeluOp;
 template <typename Backend> class TanhOp;
 template <typename Backend> class HardTanhOp;
+#endif
 
 /**
  * The ref namespace contains all code specific to the Reference backend.
@@ -140,6 +142,7 @@ extern float* spad1;
 extern float* spad2;
 }  // namespace smv
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 class SmvConvolutionOp;
 class SmvInnerProductOp;
 class SmvMaxPoolingOp;
@@ -158,6 +161,7 @@ class SmvLessOp;
 class SmvLessEqualOp;
 class SmvGreaterOp;
 class SmvGreaterEqualOp;
+#endif
 
 /**
  * SmvBackend implements a set of models of optimized DL kernels that were

--- a/smaug/core/globals.h
+++ b/smaug/core/globals.h
@@ -1,3 +1,8 @@
+/**
+ * \file globals.h
+ * \brief SMAUG Global variables.
+ */
+
 #ifndef _CORE_GLOBALS_H_
 #define _CORE_GLOBALS_H_
 

--- a/smaug/core/network.h
+++ b/smaug/core/network.h
@@ -15,9 +15,6 @@
 
 namespace smaug {
 
-template <typename Backend>
-class ReorderOp;
-
 /**
  * DataflowGraphWriter writes the current network as a dot-graph file to the
  * given ostream.

--- a/smaug/core/smaug_test.h
+++ b/smaug/core/smaug_test.h
@@ -1,3 +1,8 @@
+/**
+ * \file smaug_test.h
+ * \brief SMAUG unit test fixture.
+ */
+
 #include <fstream>
 
 #include "catch.hpp"
@@ -56,7 +61,7 @@ class SmaugTest {
     /**
      * Allocates data storage for all Tensors in the Operator.
      *
-     * @param T The data element type.
+     * @tparam T The data element type.
      * @param op The Operator.
      */
     template <typename T>
@@ -75,7 +80,7 @@ class SmaugTest {
      * Fills every input Tensor in the Operator with data by calling the
      * provided FillTensorDataFunc.
      *
-     * @param T The type of data stored in the Tensors.
+     * @tparam T The type of data stored in the Tensors.
      * @param op The Operator
      * @param fillTensorDataFunc A pointer to a function to auto-generate
      * testing data for the Tensor.

--- a/smaug/core/tensor.h
+++ b/smaug/core/tensor.h
@@ -467,7 +467,7 @@ class Tensor : public TensorBase {
     /**
      * Allocates memory to store Tensor data.
      *
-     * @params T The type of data to store.
+     * @tparam T The type of data to store.
      */
     template <typename T>
     T* allocateStorage() {

--- a/smaug/core/tensor_utils.h
+++ b/smaug/core/tensor_utils.h
@@ -1,3 +1,8 @@
+/**
+ * \file tensor_utils.h
+ * \brief Utility functions for copying/printing/tiling tensors.
+ */
+
 #ifndef _CORE_TENSOR_UTILS_H_
 #define _CORE_TENSOR_UTILS_H_
 

--- a/smaug/operators/batch_norm_op.h
+++ b/smaug/operators/batch_norm_op.h
@@ -11,12 +11,15 @@
 namespace smaug {
 
 /** \ingroup Operators
+ *
  * Implements the batch normalization layer.
  *
  * The four different parameter types to BN layers (mean, v ariance, gamma, and
  * beta) are to be provided as separate Tensors. For performance reasons, the
  * variance parameter is often precomputed as 1/sqrt(variance + eps), so
  * hardware does not need to do a square root/division operation.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class BatchNormOp : public FusedActivationOp {
@@ -115,7 +118,9 @@ class BatchNormOp : public FusedActivationOp {
     SamplingInfo sampling;
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(BatchNormOp, ReferenceBackend);
+#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/common.h
+++ b/smaug/operators/common.h
@@ -1,3 +1,8 @@
+/**
+ * \file common.h
+ * \brief Utilities for writing and invoking Aladdin kernels from Operators.
+ */
+
 #ifndef _OPERATORS_COMMON_H_
 #define _OPERATORS_COMMON_H_
 
@@ -274,7 +279,7 @@ typedef uint16_t float16;
 #define CACHELINE_SIZE 32
 #define LOG_PAGE_SIZE 12
 
-/** \defgroup VectorData
+/** \defgroup VectorData Working with SIMD in C.
  *
  * Typedefs and macros for working with vector data.
  *
@@ -345,7 +350,7 @@ typedef uint8_t v8bl_t
  * @}
  */
 
-/** \defgroup MultiDimArrays
+/** \defgroup MultiDimArrays Multi-dim arrays in C
  *
  * Use these convenience macros to cast a raw pointer into a multidimensional
  * variable-length array, which lets us use `[]` notation instead of manually
@@ -466,7 +471,7 @@ typedef uint8_t v8bl_t
 #endif
 
 
-/** \defgroup AladdinHelpers
+/** \defgroup AladdinHelpers Utilities for writing Aladdin kernels.
  *
  * Macros to assist in writing code for Aladdin/LLVM-Tracer that translates
  * into an efficient hardware model.
@@ -474,7 +479,7 @@ typedef uint8_t v8bl_t
  * @{
  */
 
-/** \defgroup AladdinMath
+/** \defgroup AladdinMath Common math functions in Aladdin
  *
  * Macros for computing the min/max of a group of elements.
  *

--- a/smaug/operators/concat_op.h
+++ b/smaug/operators/concat_op.h
@@ -10,7 +10,9 @@ namespace smaug {
 /** \ingroup Operators
  * Concatenates N Tensors along a specified axis.
  *
- * This has a backend-agnostic software-based implementation.
+ * This has a software-based implementation.
+ *
+ * @tparam Backend The Backend that sets Alignment.
  */
 template <typename Backend>
 class ConcatOp : public Operator {

--- a/smaug/operators/control_flow_ops.h
+++ b/smaug/operators/control_flow_ops.h
@@ -13,6 +13,8 @@ namespace smaug {
  * marked as dead.
  *
  * This is an integral component of implementing control flow in networks.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class SwitchOp : public Operator {

--- a/smaug/operators/convolution_op.h
+++ b/smaug/operators/convolution_op.h
@@ -16,6 +16,8 @@ namespace smaug {
  *
  * The base class for all 4D spatial convolution operators. Provides common
  * functionality for writing convolution operators.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class ConvolutionOp : public FusedActivationOp {
@@ -183,7 +185,9 @@ class ConvolutionOp : public FusedActivationOp {
     SamplingInfo sampling;
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(ConvolutionOp, ReferenceBackend);
+#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/data_op.h
+++ b/smaug/operators/data_op.h
@@ -13,6 +13,8 @@ namespace smaug {
  * This is the only operator that is not expected to have any inputs. Its
  * existence is to maintain the abstraction that the input to all other
  * operators is always provided by another Operator.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class DataOp : public Operator {

--- a/smaug/operators/depthwise_convolution_op.h
+++ b/smaug/operators/depthwise_convolution_op.h
@@ -7,6 +7,8 @@ namespace smaug {
 
 /** \ingroup Operators
  * Implements the depthwise convolution operator.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class DepthwiseConvolutionOp : public ConvolutionOp<Backend> {
@@ -66,7 +68,9 @@ class DepthwiseConvolutionOp : public ConvolutionOp<Backend> {
     }
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(DepthwiseConvolutionOp, ReferenceBackend);
+#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/eltwise_add_op.h
+++ b/smaug/operators/eltwise_add_op.h
@@ -11,6 +11,8 @@ namespace smaug {
 
 /** \ingroup Operators
  * Adds two Tensors elementwise.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class EltwiseAddOp : public EltwiseOp<Backend> {
@@ -21,7 +23,9 @@ class EltwiseAddOp : public EltwiseOp<Backend> {
     void run() override {}
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(EltwiseAddOp, ReferenceBackend);
+#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/eltwise_mul_op.h
+++ b/smaug/operators/eltwise_mul_op.h
@@ -11,6 +11,8 @@ namespace smaug {
 
 /** \ingroup Operators
  * Multiplies two Tensors elementwise.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class EltwiseMulOp : public EltwiseOp<Backend> {
@@ -21,7 +23,9 @@ class EltwiseMulOp : public EltwiseOp<Backend> {
     void run() override {}
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(EltwiseMulOp, ReferenceBackend);
+#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/eltwise_op.h
+++ b/smaug/operators/eltwise_op.h
@@ -9,6 +9,8 @@ namespace smaug {
 
 /** \ingroup Operators
  * The base class of all elementwise operators.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class EltwiseOp : public Operator {

--- a/smaug/operators/elu_op.h
+++ b/smaug/operators/elu_op.h
@@ -12,6 +12,8 @@ namespace smaug {
  * Implements the exponential linear unit function.
  *
  * Defined as: if input > 0, alpha * exp(input - 1), else input.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class EluOp : public UnaryOp<Backend> {
@@ -32,6 +34,8 @@ class EluOp : public UnaryOp<Backend> {
  * Implements the scaled exponential linear unit function.
  *
  * Defined as: lambda * elu(input).
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class SeluOp : public EluOp<Backend> {
@@ -50,8 +54,10 @@ class SeluOp : public EluOp<Backend> {
     float lambda;
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(EluOp, ReferenceBackend);
 REGISTER_SPECIAL_OP(SeluOp, ReferenceBackend);
+#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/greater_op.h
+++ b/smaug/operators/greater_op.h
@@ -11,6 +11,8 @@ namespace smaug {
 
 /** \ingroup Operators
  * Implements an elementwise greater than operator.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class GreaterOp : public EltwiseOp<Backend> {
@@ -25,6 +27,8 @@ class GreaterOp : public EltwiseOp<Backend> {
 
 /** \ingroup Operators
  * Implements an elementwise greater than or equal to operator.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class GreaterEqualOp : public EltwiseOp<Backend> {
@@ -37,8 +41,10 @@ class GreaterEqualOp : public EltwiseOp<Backend> {
     }
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(GreaterOp, ReferenceBackend);
 REGISTER_SPECIAL_OP(GreaterEqualOp, ReferenceBackend);
+#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/inner_product_op.h
+++ b/smaug/operators/inner_product_op.h
@@ -13,6 +13,8 @@ namespace smaug {
 /** \ingroup Operators
  *
  * Implements the inner product operator.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class InnerProductOp : public FusedActivationOp {
@@ -103,7 +105,10 @@ class InnerProductOp : public FusedActivationOp {
     SamplingInfo sampling;
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(InnerProductOp, ReferenceBackend);
+#endif
+
 
 }  // namespace smaug
 

--- a/smaug/operators/less_op.h
+++ b/smaug/operators/less_op.h
@@ -11,6 +11,8 @@ namespace smaug {
 
 /** \ingroup Operators
  * Implements an elementwise less-than operator.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class LessOp : public EltwiseOp<Backend> {
@@ -25,6 +27,8 @@ class LessOp : public EltwiseOp<Backend> {
 
 /** \ingroup Operators
  * Implements an elementwise less-than-or-equal-to operator.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class LessEqualOp : public EltwiseOp<Backend> {
@@ -37,8 +41,10 @@ class LessEqualOp : public EltwiseOp<Backend> {
     }
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(LessOp, ReferenceBackend);
 REGISTER_SPECIAL_OP(LessEqualOp, ReferenceBackend);
+#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/pooling_op.h
+++ b/smaug/operators/pooling_op.h
@@ -15,6 +15,8 @@ namespace smaug {
  * The pooling operator reduces the size of the input Tensor by applying a
  * windowed filter that reduces all elements in its field of view to a single
  * value.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class PoolingOp : public Operator {
@@ -145,8 +147,10 @@ class AvgPoolingOp : public PoolingOp<Backend> {
     void run() override{};
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(MaxPoolingOp, ReferenceBackend);
 REGISTER_SPECIAL_OP(AvgPoolingOp, ReferenceBackend);
+#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/ref/ref_depthwise_convolution_op.cpp
+++ b/smaug/operators/ref/ref_depthwise_convolution_op.cpp
@@ -9,11 +9,8 @@ extern "C" {
 /** \ingroup AladdinKernels
  *
  * A Reference implementation of a depthwise convolution on NCHW data with
- * valid padding.
- *
- * @param img_pad Alignment padding on the W dimension of inputs.
- * @param k_pad Alignment padding on the W dimension of weights.
- * @param res_pad Alignment padding on the W dimension of results.
+ * valid padding. The Reference backend requires no alignment padding so all
+ * _pad parameters can be zero.
  */
 void ref_conv2d_nchw_valid_padding(float* input,
                                    float* kernels,

--- a/smaug/operators/ref/ref_inner_product_op.cpp
+++ b/smaug/operators/ref/ref_inner_product_op.cpp
@@ -74,6 +74,15 @@ void ref_inner_product_ab_times_bc(float* a,
  * @param a A matrix of dimensions a_height x b_width
  * @param b A matrix of dimensions b_height x b_width
  * @param c A matrix of dimensions a_height x b_width
+ * @param a_height Number of rows in A
+ * @param b_width Number of columns in B
+ * @param b_height Number of rows in B
+ * @param a_pad Additional alignment zero-padding on a.
+ * @param b_pad Additional alignment zero-padding on b.
+ * @param c_pad Additional alignment zero-padding on c.
+ * @param act_function The activation function to apply on the result of the
+ * inner product.
+ * @param act_params Parameters to the activation function.
  */
 void ref_inner_product_ab_times_cb(float* a,
                                    float* b,

--- a/smaug/operators/relu_op.h
+++ b/smaug/operators/relu_op.h
@@ -10,6 +10,8 @@ namespace smaug {
 
 /** \ingroup Operators
   * Implements the rectified linear unit operator: max(slope * x, 0).
+ *
+ * @tparam Backend The Backend specialization of this Operator.
   */
 template <typename Backend>
 class ReluOp : public UnaryOp<Backend> {
@@ -26,7 +28,10 @@ class ReluOp : public UnaryOp<Backend> {
     float slope;
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(ReluOp, ReferenceBackend);
+#endif
+
 
 }  // namespace smaug
 

--- a/smaug/operators/reorder_op.h
+++ b/smaug/operators/reorder_op.h
@@ -11,6 +11,8 @@ namespace smaug {
  *
  * Implements a Tensor reordering operation to convert between different
  * DataLayouts.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class ReorderOp : public Operator {

--- a/smaug/operators/repeat_op.h
+++ b/smaug/operators/repeat_op.h
@@ -15,6 +15,8 @@ namespace smaug {
  * Implements a repeat operator, which replicates the contents of a Tensor
  * along each dimension a configurable number of times. This is set by the
  * `setMultiples` function.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class RepeatOp : public Operator {

--- a/smaug/operators/reshape_op.h
+++ b/smaug/operators/reshape_op.h
@@ -12,6 +12,8 @@ namespace smaug {
  * Implements the reshape operator, which changes the dimensionality of a
  * Tensor while retaining the same number of elements. The output need not be
  * of the same DataLayout.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class ReshapeOp : public Operator {

--- a/smaug/operators/sigmoid_op.h
+++ b/smaug/operators/sigmoid_op.h
@@ -11,6 +11,8 @@ namespace smaug {
 /** \ingroup Operators
  *
  * Implements the sigmoid operator, defined as 1/(1 + exp(-input)).
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class SigmoidOp : public UnaryOp<Backend> {
@@ -21,7 +23,9 @@ class SigmoidOp : public UnaryOp<Backend> {
     void run() override {}
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(SigmoidOp, ReferenceBackend);
+#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/smv/kernels/convolution_simd.c
+++ b/smaug/operators/smv/kernels/convolution_simd.c
@@ -24,11 +24,11 @@ extern "C" {
  * @param inputs_dims Dimensions of the inputs.
  * @param weights_dims Dimensions of the weights.
  * @param results_dims Dimensions of the results.
- * @param inputs_align_pad Align padding size on the channel dimension of the
- *        inputs.
- * @param weights_pad Align padding size on the channel dimension of the
+ * @param inputs_align_pad Alignment padding size on the channel dimension of
+ *        the inputs.
+ * @param weights_pad Alignment padding size on the channel dimension of the
  *        weights.
- * @param results_pad Align padding size on the channel dimension of the
+ * @param results_pad Alignment padding size on the channel dimension of the
  *        results.
  * @param inputs_halo_pad Padding sizes on top, bottom, left and right of the
  * input 2D feature maps.
@@ -41,9 +41,14 @@ extern "C" {
  * @param accumulate If the original weight tensor is tiled channelwise, this
  *        should be set to true in order to avoid resetting the result buffer
  *        for non-first weight tiles.
+ * @param read_inputs Load inputs from the host. Set to false if the input
+ *        activations can be reused from the last invocation.
+ * @param read_weights Load weights from the host. Set to false if the weights
+ *        can be reused from the last invocation.
  * @param send_results Send the results to the host memory if this is true.
  * @param act_function Activation function the operator runs.
  * @param act_params Parameters for the activation function.
+ * @param sampling Simulation samplng settings.
  */
 void smv_conv3d_nhwc_vec_fxp(float16* host_inputs,
                              float16* host_weights,

--- a/smaug/operators/smv/kernels/load_store_fp16_data.h
+++ b/smaug/operators/smv/kernels/load_store_fp16_data.h
@@ -1,3 +1,8 @@
+/**
+ * \file load_store_fp16_data.h
+ * \brief Aladdin kernels to load/store FP16 data to/from host memory.
+ */
+
 #ifndef _OPERATORS_SMV_KERNELS_LOAD_STORE_FP16_DATA_H_
 #define _OPERATORS_SMV_KERNELS_LOAD_STORE_FP16_DATA_H_
 

--- a/smaug/operators/smv/kernels/matrix_multiply.c
+++ b/smaug/operators/smv/kernels/matrix_multiply.c
@@ -49,9 +49,12 @@ extern "C" {
  * @param accumulate If the original b tensor is tiled on activations, this
  *        should be set to true in order to avoid resetting the result buffer
  *        for knon-first b tiles.
+ * @param read_inputs Load inputs from the host. Set to false if the input
+ *        activations can be reused from the last invocation.
  * @param send_results Send the results to the host memory if this is true.
  * @param act_function Activation function the operator runs.
  * @param act_params Parameters for the activation function.
+ * @param sampling Simulation samplng settings.
  */
 void smv_matrix_multiply_transpose_nc_vec_fxp(float16* host_a,
                                               float16* host_b,

--- a/smaug/operators/smv/kernels/pooling.c
+++ b/smaug/operators/smv/kernels/pooling.c
@@ -20,7 +20,6 @@ extern "C" {
  * @param inputs Local inputs buffer in NHWC.
  * @param results Local results buffer in NHWC.
  * @param inputs_dims Dimensions of the inputs.
- * @param weights_dims Dimensions of the weights.
  * @param results_dims Dimensions of the results.
  * @param inputs_pad Align padding size on the channel dimension of the
  *        inputs.
@@ -32,6 +31,7 @@ extern "C" {
  * @param col_stride Stride size on the col dimension.
  * @param ofmap_start If the results contains more channels than the inputs,
  *        start from this one. Otherwise this should always be zero.
+ * @param sampling Simulation samplng settings.
  */
 void smv_maxpooling_nhwc_vec_fxp(float16* host_inputs,
                                  float16* host_results,
@@ -142,25 +142,26 @@ void smv_maxpooling_nhwc_vec_fxp(float16* host_inputs,
  * An average-pooling operation on SMV with NHWC format. This is the
  * vectorized implementation.
  *
+ * This requires a blocked channel data format (GNHWC), where G = channels/8,
+ * and the last dimension = chans = 8. The last dimension MUST be 8.
+ * This supports arbitrary pooling sizes and strides.
+ *
  * @param host_inputs Host inputs buffer in NHWC.
  * @param host_results Host results buffer in NHWC.
  * @param inputs Local inputs buffer in NHWC.
  * @param results Local results buffer in NHWC.
  * @param inputs_dims Dimensions of the inputs.
- * @param weights_dims Dimensions of the weights.
  * @param results_dims Dimensions of the results.
- * @param inputs_pad Align padding size on the channel dimension of the
- *       inputs.
- * @param results_pad Align padding size on the channel dimension of the results.
+ * @param inputs_pad Align padding size on the channel dimension of the inputs.
+ * @param results_pad Align padding size on the channel dimension of the
+ *        results.
  * @param pool_rows Row size of the pooling function.
  * @param pool_cols Column size of the pooling function.
  * @param row_stride Stride size on the row dimension.
  * @param col_stride Stride size on the col dimension.
- * @param ofmap_start If the results contains more channels than the inputs, start
- *       from this one. Otherwise this should always be zero.
- * This requires a blocked channel data format (GNHWC), where G = channels/8,
- * and the last dimension = chans = 8. The last dimension MUST be 8.
- * This supports arbitrary pooling sizes and strides.
+ * @param ofmap_start If the results contains more channels than the inputs,
+ *        start from this one. Otherwise this should always be zero.
+ * @param sampling Simulation samplng settings.
  */
 void smv_avgpooling_nhwc_vec_fxp(float16* host_inputs,
                                  float16* host_results,

--- a/smaug/operators/softmax_op.h
+++ b/smaug/operators/softmax_op.h
@@ -11,6 +11,8 @@ namespace smaug {
 /** \ingroup Operators
  *
  * Implements the softmax operator.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class SoftmaxOp : public UnaryOp<Backend> {
@@ -21,7 +23,9 @@ class SoftmaxOp : public UnaryOp<Backend> {
     void run() override {}
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(SoftmaxOp, ReferenceBackend);
+#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/split_op.h
+++ b/smaug/operators/split_op.h
@@ -14,6 +14,8 @@ namespace smaug {
  *
  * Implements the split operator, which divides a Tensor into N output Tensors
  * along a specified dimension.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class SplitOp : public Operator {

--- a/smaug/operators/tanh_op.h
+++ b/smaug/operators/tanh_op.h
@@ -10,6 +10,8 @@ namespace smaug {
 
 /** \ingroup Operators
  * Implements the tanh operator.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class TanhOp : public UnaryOp<Backend> {
@@ -23,6 +25,8 @@ class TanhOp : public UnaryOp<Backend> {
 /** \ingroup Operators
  * Implements the hard tanh operator, which bounds the min and max value of the
  * tanh operator.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class HardTanhOp : public UnaryOp<Backend> {
@@ -46,8 +50,10 @@ class HardTanhOp : public UnaryOp<Backend> {
     float max;
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(TanhOp, ReferenceBackend);
 REGISTER_SPECIAL_OP(HardTanhOp, ReferenceBackend);
+#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/unary_op.h
+++ b/smaug/operators/unary_op.h
@@ -12,6 +12,8 @@ namespace smaug {
  *
  * A base class for all unary operators: operators that only take a single
  * input. Unary operators can produce multiple output Tensors.
+ *
+ * @tparam Backend The Backend specialization of this Operator.
  */
 template <typename Backend>
 class UnaryOp : public Operator {


### PR DESCRIPTION
This addresses a bunch of Doxygen warnings (missing titles, invalid parameters, etc), fixes the generated file hierarchy, removes some macros that were causing problems, and deletes SMIV/compression code from documentation. In total, warnings drop from 1500 to 1100.