### PR TITLE
Use Doxygen for C++ API documentation instead of Sphinx.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -16,6 +16,7 @@ help:
 
 html:
 	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	doxygen source/Doxyfile
 
 clean:
 	@rm -rf $(SOURCEDIR)/api/* $(BUILDDIR)/*

--- a/docs/source/Doxyfile
+++ b/docs/source/Doxyfile
@@ -44,7 +44,7 @@ PROJECT_NUMBER         =
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "Simulating Machine Learning Accelerators on gem5-Aladdin"
+PROJECT_BRIEF          = "Simulating Machine Learning Applications on gem5-Aladdin"
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55

--- a/docs/source/Doxyfile
+++ b/docs/source/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = ../build
+OUTPUT_DIRECTORY       = build
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -1132,7 +1132,7 @@ IGNORE_PREFIX          =
 # If the GENERATE_HTML tag is set to YES, doxygen will generate HTML output
 # The default value is: YES.
 
-GENERATE_HTML          = NO
+GENERATE_HTML          = YES
 
 # The HTML_OUTPUT tag is used to specify where the HTML docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of
@@ -2006,7 +2006,7 @@ MAN_LINKS              = NO
 # captures the structure of the code including all documentation.
 # The default value is: NO.
 
-GENERATE_XML           = YES
+GENERATE_XML           = NO
 
 # The XML_OUTPUT tag is used to specify where the XML pages will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,46 +38,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
     'sphinx.ext.autosectionlabel',
-    'breathe',
-    'exhale',
 ]
-
-# Setup absolute paths for communicating with breathe / exhale where
-# items are expected / should be trimmed by.
-breathe_projects = {
-    "SMAUG": os.path.join(os.environ['SMAUG_HOME'], 'docs/build/xml')
-}
-breathe_default_project = "SMAUG"
-
-# Setup the exhale extension
-exhale_args = {
-    ############################################################################
-    # These arguments are required.                                            #
-    ############################################################################
-    "containmentFolder": "./api",
-    "rootFileName": "library_root.rst",
-    "rootFileTitle": "Library API",
-    "doxygenStripFromPath": os.environ['SMAUG_HOME'],
-    ############################################################################
-    # Suggested optional arguments.                                            #
-    ############################################################################
-    "createTreeView": True,
-    "exhaleExecutesDoxygen": True,
-    "exhaleUseDoxyfile": True,
-    "verboseBuild": True,
-    ############################################################################
-    # Individual page layout example configuration.                            #
-    ############################################################################
-    # Example of adding contents directives on custom kinds with custom title
-    "contentsTitle": "Page Contents",
-    "kindsWithContentsDirectives": ["class", "file", "namespace", "struct"],
-    ############################################################################
-    # Main library page layout example configuration.                          #
-    ############################################################################
-    "afterTitleDescription": textwrap.dedent(u'''
-        Welcome to the developer reference for the SMAUG C++ API.
-    '''),
-}
 
 autodoc_default_flags = ['members']
 autoclass_content = 'both'
@@ -91,7 +52,6 @@ templates_path = ['_templates']
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
-
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,5 +26,4 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`modindex`
 * :ref:`search`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@
 
 SMAUG DOCUMENTATION
 ===================
-SMAUG is a deep learning framework that enables end-to-end simulation of DL models on custom SoCs with a variety of hardware accelerators. 
+SMAUG is a deep learning framework that enables end-to-end simulation of DL models on custom SoCs with a variety of hardware accelerators.
 
 .. toctree::
    :maxdepth: 1
@@ -16,11 +16,11 @@ SMAUG is a deep learning framework that enables end-to-end simulation of DL mode
    math
    tensor
 
-.. toctree::
-   :maxdepth: 2
-   :caption: C++ API
+C++ API
+-------
 
-   api/library_root
+* `C++ API <../doxygen_html/index.html>`_
+
 
 Indices and tables
 ==================


### PR DESCRIPTION
Sphinx + Breathe + Exhale is too complicated of a pipeline, and while
they look more a bit more modern, Doxygen's presentation is more useful.
Python tutorials will be written in rst, and C++ tutorials will be
written in Markdown.