### PR TITLE
Add brief descriptions for everything

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -16,6 +16,7 @@ help:
 
 html:
 	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	doxygen source/Doxyfile
 
 clean:
 	@rm -rf $(SOURCEDIR)/api/* $(BUILDDIR)/*

--- a/docs/source/Doxyfile
+++ b/docs/source/Doxyfile
@@ -44,7 +44,7 @@ PROJECT_NUMBER         =
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "Simulating Machine Learning Accelerators on gem5-Aladdin"
+PROJECT_BRIEF          = "Simulating Machine Learning Applications on gem5-Aladdin"
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55

--- a/docs/source/Doxyfile
+++ b/docs/source/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = ../build
+OUTPUT_DIRECTORY       = build
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -1132,7 +1132,7 @@ IGNORE_PREFIX          =
 # If the GENERATE_HTML tag is set to YES, doxygen will generate HTML output
 # The default value is: YES.
 
-GENERATE_HTML          = NO
+GENERATE_HTML          = YES
 
 # The HTML_OUTPUT tag is used to specify where the HTML docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of
@@ -2006,7 +2006,7 @@ MAN_LINKS              = NO
 # captures the structure of the code including all documentation.
 # The default value is: NO.
 
-GENERATE_XML           = YES
+GENERATE_XML           = NO
 
 # The XML_OUTPUT tag is used to specify where the XML pages will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of

--- a/docs/source/Doxyfile
+++ b/docs/source/Doxyfile
@@ -195,7 +195,7 @@ SHORT_NAMES            = NO
 # description.)
 # The default value is: NO.
 
-JAVADOC_AUTOBRIEF      = NO
+JAVADOC_AUTOBRIEF      = YES
 
 # If the JAVADOC_BANNER tag is set to YES then doxygen will interpret a line
 # such as
@@ -2172,7 +2172,8 @@ PREDEFINED             = __attribute__(x)= \
                          __GNUC__ \
                          ALWAYS_INLINE \
                          ASSERT \
-                         ASSUME_ALIGNED
+                         ASSUME_ALIGNED \
+                         REGISTER_SPECIAL_OP
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,46 +38,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
     'sphinx.ext.autosectionlabel',
-    'breathe',
-    'exhale',
 ]
-
-# Setup absolute paths for communicating with breathe / exhale where
-# items are expected / should be trimmed by.
-breathe_projects = {
-    "SMAUG": os.path.join(os.environ['SMAUG_HOME'], 'docs/build/xml')
-}
-breathe_default_project = "SMAUG"
-
-# Setup the exhale extension
-exhale_args = {
-    ############################################################################
-    # These arguments are required.                                            #
-    ############################################################################
-    "containmentFolder": "./api",
-    "rootFileName": "library_root.rst",
-    "rootFileTitle": "Library API",
-    "doxygenStripFromPath": os.environ['SMAUG_HOME'],
-    ############################################################################
-    # Suggested optional arguments.                                            #
-    ############################################################################
-    "createTreeView": True,
-    "exhaleExecutesDoxygen": True,
-    "exhaleUseDoxyfile": True,
-    "verboseBuild": True,
-    ############################################################################
-    # Individual page layout example configuration.                            #
-    ############################################################################
-    # Example of adding contents directives on custom kinds with custom title
-    "contentsTitle": "Page Contents",
-    "kindsWithContentsDirectives": ["class", "file", "namespace", "struct"],
-    ############################################################################
-    # Main library page layout example configuration.                          #
-    ############################################################################
-    "afterTitleDescription": textwrap.dedent(u'''
-        Welcome to the developer reference for the SMAUG C++ API.
-    '''),
-}
 
 autodoc_default_flags = ['members']
 autoclass_content = 'both'
@@ -91,7 +52,6 @@ templates_path = ['_templates']
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
-
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,5 +26,4 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`modindex`
 * :ref:`search`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@
 
 SMAUG DOCUMENTATION
 ===================
-SMAUG is a deep learning framework that enables end-to-end simulation of DL models on custom SoCs with a variety of hardware accelerators. 
+SMAUG is a deep learning framework that enables end-to-end simulation of DL models on custom SoCs with a variety of hardware accelerators.
 
 .. toctree::
    :maxdepth: 1
@@ -16,11 +16,11 @@ SMAUG is a deep learning framework that enables end-to-end simulation of DL mode
    math
    tensor
 
-.. toctree::
-   :maxdepth: 2
-   :caption: C++ API
+C++ API
+-------
 
-   api/library_root
+* `C++ API <../doxygen_html/index.html>`_
+
 
 Indices and tables
 ==================

--- a/smaug/core/datatypes.h
+++ b/smaug/core/datatypes.h
@@ -10,8 +10,9 @@ namespace smaug {
 using float16 = uint16_t;
 
 /**
- * ToDataType provides a compile-time way to convert a C type (e.g. double,
- * bool) to a SMAUG DataType enum (defined in smaug/core/types.proto).
+ * Provides compile-time conversion from C types to SMAUG DataTypes.
+ *
+ * SMAUG DataType enum are defined in smaug/core/types.proto.
  */
 template <typename T>
 struct ToDataType {};
@@ -49,6 +50,11 @@ struct ToDataType<bool> {
     static const DataType dataType = Bool;
 };
 
+/**
+ * Provides compile-time conversion from SMAUG DataType to C type.
+ *
+ * SMAUG DataType enum are defined in smaug/core/types.proto.
+ */
 template <enum DataType>
 struct FromDataType {};
 

--- a/smaug/core/tensor.h
+++ b/smaug/core/tensor.h
@@ -541,7 +541,8 @@ class Tensor : public TensorBase {
     std::shared_ptr<void> tensorData;
 };
 
-/* A multidimensional container of Tensors..
+/**
+ * A multidimensional container of Tensors.
  *
  * Each of the tensors in a TiledTensor represents one tile or rectangular
  * section of a large tensor.  TileTensor can be iterated over via a
@@ -614,7 +615,7 @@ class TiledTensor : public TensorBase {
    /** Copies data (if needed) to all the tiles from the original Tensor. */
    void copyDataToAllTiles();
 
-   /** 
+   /**
     * Copies data from the TiledTensor into the original Tensor. We name it
     * "untile" because what it does reverses the tiling process.
     */
@@ -636,7 +637,7 @@ class TiledTensor : public TensorBase {
        /** True if we have copied data to this tile. */
        bool hasData;
 
-       /** 
+       /**
         * Construct a new blank Tile.
         *
         * Set the properties of this Tile using TiledTensor::setTile
@@ -647,11 +648,11 @@ class TiledTensor : public TensorBase {
    /**
     * Specifies what to do with the data in the original Tensor and tiles.
     */
-   enum TileDataOperation { 
+   enum TileDataOperation {
      /** Copies data from a contiguous Tensor to the tiles. */
-     Scatter, 
+     Scatter,
      /** Copies data from the tiles to a contiguous Tensor. */
-     Gather 
+     Gather
    };
 
    struct CopyTilesArgs {

--- a/smaug/operators/batch_norm_op.h
+++ b/smaug/operators/batch_norm_op.h
@@ -12,7 +12,7 @@ namespace smaug {
 
 /** \ingroup Operators
  *
- * Implements the batch normalization layer.
+ * \brief Implements the batch normalization layer.
  *
  * The four different parameter types to BN layers (mean, v ariance, gamma, and
  * beta) are to be provided as separate Tensors. For performance reasons, the
@@ -118,9 +118,7 @@ class BatchNormOp : public FusedActivationOp {
     SamplingInfo sampling;
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(BatchNormOp, ReferenceBackend);
-#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/concat_op.h
+++ b/smaug/operators/concat_op.h
@@ -8,7 +8,7 @@
 namespace smaug {
 
 /** \ingroup Operators
- * Concatenates N Tensors along a specified axis.
+ * \brief Concatenates N Tensors along a specified axis.
  *
  * This has a software-based implementation.
  *

--- a/smaug/operators/control_flow_ops.h
+++ b/smaug/operators/control_flow_ops.h
@@ -8,7 +8,10 @@
 namespace smaug {
 
 /** \ingroup Operators
- * The switch operator passes an input Tensor to one of two output tensors,
+ *
+ * \brief Conditionally forwards an input to one of two outputs.
+ *
+ * The switch operator copies an input Tensor to one of two output tensors,
  * depending on whether the specified predicate is true. The other tensor is
  * marked as dead.
  *
@@ -78,7 +81,10 @@ class SwitchOp : public Operator {
 };
 
 /** \ingroup Operators
- * A merge operator takes multiple tensors, all but one of which should be
+ *
+ * \brief Forwards the first live input to its output.
+ *
+ * The merge operator takes multiple tensors, all but one of which should be
  * dead, and copies the one live Tensor to its output.
  */
 template <typename Backend>

--- a/smaug/operators/convolution_op.h
+++ b/smaug/operators/convolution_op.h
@@ -14,8 +14,9 @@ namespace smaug {
 
 /** \ingroup Operators
  *
- * The base class for all 4D spatial convolution operators. Provides common
- * functionality for writing convolution operators.
+ * \brief The base class for all 4D spatial convolution operators.
+ *
+ * Provides common * functionality for writing convolution operators.
  *
  * @tparam Backend The Backend specialization of this Operator.
  */
@@ -185,9 +186,7 @@ class ConvolutionOp : public FusedActivationOp {
     SamplingInfo sampling;
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(ConvolutionOp, ReferenceBackend);
-#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/data_op.h
+++ b/smaug/operators/data_op.h
@@ -8,7 +8,8 @@
 namespace smaug {
 
 /** \ingroup Operators
- * A data operator contains a Tensor that it exposes as its only Output.
+ *
+ * \brief Exposes a Tensor as its only output.
  *
  * This is the only operator that is not expected to have any inputs. Its
  * existence is to maintain the abstraction that the input to all other

--- a/smaug/operators/depthwise_convolution_op.h
+++ b/smaug/operators/depthwise_convolution_op.h
@@ -6,7 +6,8 @@
 namespace smaug {
 
 /** \ingroup Operators
- * Implements the depthwise convolution operator.
+ *
+ * \brief Implements the depthwise convolution operator.
  *
  * @tparam Backend The Backend specialization of this Operator.
  */
@@ -68,9 +69,7 @@ class DepthwiseConvolutionOp : public ConvolutionOp<Backend> {
     }
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(DepthwiseConvolutionOp, ReferenceBackend);
-#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/eltwise_add_op.h
+++ b/smaug/operators/eltwise_add_op.h
@@ -10,7 +10,8 @@
 namespace smaug {
 
 /** \ingroup Operators
- * Adds two Tensors elementwise.
+ *
+ * \brief Adds two Tensors elementwise.
  *
  * @tparam Backend The Backend specialization of this Operator.
  */
@@ -23,9 +24,7 @@ class EltwiseAddOp : public EltwiseOp<Backend> {
     void run() override {}
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(EltwiseAddOp, ReferenceBackend);
-#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/eltwise_mul_op.h
+++ b/smaug/operators/eltwise_mul_op.h
@@ -10,7 +10,8 @@
 namespace smaug {
 
 /** \ingroup Operators
- * Multiplies two Tensors elementwise.
+ *
+ * \brief Multiplies two Tensors elementwise.
  *
  * @tparam Backend The Backend specialization of this Operator.
  */
@@ -23,9 +24,7 @@ class EltwiseMulOp : public EltwiseOp<Backend> {
     void run() override {}
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(EltwiseMulOp, ReferenceBackend);
-#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/eltwise_op.h
+++ b/smaug/operators/eltwise_op.h
@@ -8,7 +8,8 @@
 namespace smaug {
 
 /** \ingroup Operators
- * The base class of all elementwise operators.
+ *
+ * \brief The base class of all elementwise operators.
  *
  * @tparam Backend The Backend specialization of this Operator.
  */

--- a/smaug/operators/elu_op.h
+++ b/smaug/operators/elu_op.h
@@ -9,7 +9,8 @@
 namespace smaug {
 
 /** \ingroup Operators
- * Implements the exponential linear unit function.
+ *
+ * \brief Implements the exponential linear unit function.
  *
  * Defined as: if input > 0, alpha * exp(input - 1), else input.
  *
@@ -31,7 +32,8 @@ class EluOp : public UnaryOp<Backend> {
 };
 
 /** \ingroup Operators
- * Implements the scaled exponential linear unit function.
+ *
+ * \brief Implements the scaled exponential linear unit function.
  *
  * Defined as: lambda * elu(input).
  *
@@ -54,10 +56,8 @@ class SeluOp : public EluOp<Backend> {
     float lambda;
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(EluOp, ReferenceBackend);
 REGISTER_SPECIAL_OP(SeluOp, ReferenceBackend);
-#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/fused_activation_op.h
+++ b/smaug/operators/fused_activation_op.h
@@ -10,7 +10,8 @@
 namespace smaug {
 
 /** \ingroup Operators
- * An Operator fused with an activation function.
+ *
+ * \brief An Operator fused with an activation function.
  *
  * This is an optimized operator that reduces memory/compute by directly
  * computing the activation function on its output.  This is a parent class of

--- a/smaug/operators/greater_op.h
+++ b/smaug/operators/greater_op.h
@@ -10,7 +10,7 @@
 namespace smaug {
 
 /** \ingroup Operators
- * Implements an elementwise greater than operator.
+ * \brief Implements an elementwise greater than operator.
  *
  * @tparam Backend The Backend specialization of this Operator.
  */
@@ -26,7 +26,7 @@ class GreaterOp : public EltwiseOp<Backend> {
 };
 
 /** \ingroup Operators
- * Implements an elementwise greater than or equal to operator.
+ * \brief Implements an elementwise greater than or equal to operator.
  *
  * @tparam Backend The Backend specialization of this Operator.
  */
@@ -41,10 +41,8 @@ class GreaterEqualOp : public EltwiseOp<Backend> {
     }
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(GreaterOp, ReferenceBackend);
 REGISTER_SPECIAL_OP(GreaterEqualOp, ReferenceBackend);
-#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/inner_product_op.h
+++ b/smaug/operators/inner_product_op.h
@@ -12,7 +12,7 @@ namespace smaug {
 
 /** \ingroup Operators
  *
- * Implements the inner product operator.
+ * \brief Implements the inner product operator.
  *
  * @tparam Backend The Backend specialization of this Operator.
  */
@@ -105,9 +105,7 @@ class InnerProductOp : public FusedActivationOp {
     SamplingInfo sampling;
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(InnerProductOp, ReferenceBackend);
-#endif
 
 
 }  // namespace smaug

--- a/smaug/operators/less_op.h
+++ b/smaug/operators/less_op.h
@@ -10,7 +10,8 @@
 namespace smaug {
 
 /** \ingroup Operators
- * Implements an elementwise less-than operator.
+ *
+ * \brief Implements an elementwise less-than operator.
  *
  * @tparam Backend The Backend specialization of this Operator.
  */
@@ -26,7 +27,8 @@ class LessOp : public EltwiseOp<Backend> {
 };
 
 /** \ingroup Operators
- * Implements an elementwise less-than-or-equal-to operator.
+ *
+ * \brief Implements an elementwise less-than-or-equal-to operator.
  *
  * @tparam Backend The Backend specialization of this Operator.
  */
@@ -41,10 +43,8 @@ class LessEqualOp : public EltwiseOp<Backend> {
     }
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(LessOp, ReferenceBackend);
 REGISTER_SPECIAL_OP(LessEqualOp, ReferenceBackend);
-#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/pooling_op.h
+++ b/smaug/operators/pooling_op.h
@@ -10,7 +10,7 @@ namespace smaug {
 
 /** \ingroup Operators
  *
- * Implements a pooling operator.
+ * \brief Implements a pooling operator.
  *
  * The pooling operator reduces the size of the input Tensor by applying a
  * windowed filter that reduces all elements in its field of view to a single
@@ -120,7 +120,8 @@ class PoolingOp : public Operator {
 };
 
 /** \ingroup Operators
- * Implements the max-pooling operator.
+ *
+ * \brief Implements the max-pooling operator.
  */
 template <typename Backend>
 class MaxPoolingOp : public PoolingOp<Backend> {
@@ -134,7 +135,8 @@ class MaxPoolingOp : public PoolingOp<Backend> {
 };
 
 /** \ingroup Operators
- * Implements the arithmetic-average-pooling operator.
+ *
+ * \brief Implements the arithmetic-average-pooling operator.
  */
 template <typename Backend>
 class AvgPoolingOp : public PoolingOp<Backend> {
@@ -147,10 +149,8 @@ class AvgPoolingOp : public PoolingOp<Backend> {
     void run() override{};
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(MaxPoolingOp, ReferenceBackend);
 REGISTER_SPECIAL_OP(AvgPoolingOp, ReferenceBackend);
-#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/relu_op.h
+++ b/smaug/operators/relu_op.h
@@ -9,7 +9,8 @@
 namespace smaug {
 
 /** \ingroup Operators
-  * Implements the rectified linear unit operator: max(slope * x, 0).
+ *
+ * \brief Implements the rectified linear unit operator: max(slope * x, 0).
  *
  * @tparam Backend The Backend specialization of this Operator.
   */
@@ -28,9 +29,7 @@ class ReluOp : public UnaryOp<Backend> {
     float slope;
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(ReluOp, ReferenceBackend);
-#endif
 
 
 }  // namespace smaug

--- a/smaug/operators/reorder_op.h
+++ b/smaug/operators/reorder_op.h
@@ -9,7 +9,7 @@ namespace smaug {
 
 /** \ingroup Operators
  *
- * Implements a Tensor reordering operation to convert between different
+ * \brief Implements a Tensor reordering operation to convert between different
  * DataLayouts.
  *
  * @tparam Backend The Backend specialization of this Operator.
@@ -148,6 +148,8 @@ class ReorderOp : public Operator {
 };
 
 /** \ingroup FlattenOp
+ *
+ * \brief Flattens each batch of a Tensor.
  *
  * Implements a flattening operation that squashes any Tensor DataLayout into
  * NC; that is, each batch in a Tensor is flattened into a single dimension.

--- a/smaug/operators/repeat_op.h
+++ b/smaug/operators/repeat_op.h
@@ -12,6 +12,8 @@ namespace smaug {
 
 /** \ingroup Operators
  *
+ * \brief Replicates a Tensor's data among all dimensions.
+ *
  * Implements a repeat operator, which replicates the contents of a Tensor
  * along each dimension a configurable number of times. This is set by the
  * `setMultiples` function.

--- a/smaug/operators/reshape_op.h
+++ b/smaug/operators/reshape_op.h
@@ -9,6 +9,8 @@ namespace smaug {
 
 /** \ingroup Operators
  *
+ * \brief Changes the Tensor's shape while retaining the number of elements.
+ *
  * Implements the reshape operator, which changes the dimensionality of a
  * Tensor while retaining the same number of elements. The output need not be
  * of the same DataLayout.

--- a/smaug/operators/sigmoid_op.h
+++ b/smaug/operators/sigmoid_op.h
@@ -10,7 +10,7 @@ namespace smaug {
 
 /** \ingroup Operators
  *
- * Implements the sigmoid operator, defined as 1/(1 + exp(-input)).
+ * \brief Implements the sigmoid operator, defined as 1/(1 + exp(-input)).
  *
  * @tparam Backend The Backend specialization of this Operator.
  */
@@ -23,9 +23,7 @@ class SigmoidOp : public UnaryOp<Backend> {
     void run() override {}
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(SigmoidOp, ReferenceBackend);
-#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/softmax_op.h
+++ b/smaug/operators/softmax_op.h
@@ -10,7 +10,7 @@ namespace smaug {
 
 /** \ingroup Operators
  *
- * Implements the softmax operator.
+ * \brief Implements the softmax operator.
  *
  * @tparam Backend The Backend specialization of this Operator.
  */
@@ -23,9 +23,7 @@ class SoftmaxOp : public UnaryOp<Backend> {
     void run() override {}
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(SoftmaxOp, ReferenceBackend);
-#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/split_op.h
+++ b/smaug/operators/split_op.h
@@ -12,8 +12,8 @@ namespace smaug {
 
 /** \ingroup Operators
  *
- * Implements the split operator, which divides a Tensor into N output Tensors
- * along a specified dimension.
+ * \brief Implements the split operator, which divides a Tensor into N output
+ * Tensors along a specified dimension.
  *
  * @tparam Backend The Backend specialization of this Operator.
  */

--- a/smaug/operators/tanh_op.h
+++ b/smaug/operators/tanh_op.h
@@ -9,7 +9,8 @@
 namespace smaug {
 
 /** \ingroup Operators
- * Implements the tanh operator.
+ *
+ * \brief Implements the tanh operator.
  *
  * @tparam Backend The Backend specialization of this Operator.
  */
@@ -23,8 +24,9 @@ class TanhOp : public UnaryOp<Backend> {
 };
 
 /** \ingroup Operators
- * Implements the hard tanh operator, which bounds the min and max value of the
- * tanh operator.
+ *
+ * \brief Implements the hard tanh operator, which bounds the min and max value
+ * of the tanh operator.
  *
  * @tparam Backend The Backend specialization of this Operator.
  */
@@ -50,10 +52,8 @@ class HardTanhOp : public UnaryOp<Backend> {
     float max;
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
 REGISTER_SPECIAL_OP(TanhOp, ReferenceBackend);
 REGISTER_SPECIAL_OP(HardTanhOp, ReferenceBackend);
-#endif
 
 }  // namespace smaug
 

--- a/smaug/operators/unary_op.h
+++ b/smaug/operators/unary_op.h
@@ -10,8 +10,9 @@ namespace smaug {
 
 /** \ingroup Operators
  *
- * A base class for all unary operators: operators that only take a single
- * input. Unary operators can produce multiple output Tensors.
+ * \brief Base class for all operators with one input.
+ *
+ * Unary operators can produce multiple output Tensors.
  *
  * @tparam Backend The Backend specialization of this Operator.
  */


### PR DESCRIPTION
This produces a short description of the method/class/variable in the
listing, and only if a more detailed description exists will a larger
block for it be generated further down. This is mostly automatic, but
sometimes Doxygen needs a bit more help.

Also, removes the ugly DOXYGEN_SHOULD_SKIP_THIS macro - this was only
used for Exhale.