### PR TITLE
Place Doxygen C++ API HTML under the main html folder.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,4 +19,4 @@ html:
 	doxygen source/Doxyfile
 
 clean:
-	@rm -rf $(SOURCEDIR)/api/* $(BUILDDIR)/*
+	@rm -rf $(BUILDDIR)/*

--- a/docs/source/Doxyfile
+++ b/docs/source/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = build
+OUTPUT_DIRECTORY       = build/html
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,7 +19,7 @@ SMAUG is a deep learning framework that enables end-to-end simulation of DL mode
 C++ API
 -------
 
-* `C++ API <../doxygen_html/index.html>`_
+* `C++ API <doxygen_html/index.html>`_
 
 
 Indices and tables


### PR DESCRIPTION
The smaug_docs repo is currently set up with docs at the root of the
repo, rather than under a subdirectory. Adding C++ API as a subdirectory
under html/ (rather than outside html/) is cleaner.