### PR TITLE
tests: Add simulation sweeps in CircleCI build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
           name: Build
           command: |
             make all -j4
+            make tracer -j4
             make test -j4
       - run:
           name: Run unit tests
@@ -22,15 +23,20 @@ jobs:
             export PYTHONPATH=$SMAUG_HOME/build:$PYTHONPATH
             make test-run
       - run:
+          name: Run simulation sweeps
+          command: |
+            # Download the gem5 binary.
+            python .circleci/download_artifacts.py --api_token=${GEM5_ALADDIN_BUILD_ARTIFACT_TOKEN} --project=gem5-aladdin --artifact_name=gem5.opt --user=${USER} --download_loc=/tmp --filter=${BUILD_ARTIFACT_FILTER} --branch=${BUILD_ARTIFACT_BRANCH}
+            chmod +x /tmp/gem5.opt
+            ln -s /usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4.3.0 /usr/lib/x86_64-linux-gnu/libtcmalloc.so.4
+            # We have to use only 1 thread to not go OOM.
+            python .circleci/run_simulation_sweeps.py --sweep-file=.circleci/sweep.json --gem5-binary=/tmp/gem5.opt --num-threads=1
+      - run:
           name: Build documentation
           command: |
             export PYTHONPATH=$SMAUG_HOME/build:$PYTHONPATH
             cd docs
             make html
-      - run:
-          name: Download latest gem5-aladdin binary
-          command:
-            python .circleci/download_artifacts.py --api_token=${GEM5_ALADDIN_BUILD_ARTIFACT_TOKEN} --project=gem5-aladdin --artifact_name=gem5.opt --user=${USER} --download_loc=/tmp --filter=${BUILD_ARTIFACT_FILTER} --branch=${BUILD_ARTIFACT_BRANCH}
       - persist_to_workspace:
           root: docs
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,6 @@ jobs:
             # Download the gem5 binary.
             python .circleci/download_artifacts.py --api_token=${GEM5_ALADDIN_BUILD_ARTIFACT_TOKEN} --project=gem5-aladdin --artifact_name=gem5.opt --user=${USER} --download_loc=/tmp --filter=${BUILD_ARTIFACT_FILTER} --branch=${BUILD_ARTIFACT_BRANCH}
             chmod +x /tmp/gem5.opt
-            ln -s /usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4.3.0 /usr/lib/x86_64-linux-gnu/libtcmalloc.so.4
             # We have to use only 1 thread to not go OOM.
             python .circleci/run_simulation_sweeps.py --sweep-file=.circleci/sweep.json --gem5-binary=/tmp/gem5.opt --num-threads=1
       - run:

--- a/.circleci/run_simulation_sweeps.py
+++ b/.circleci/run_simulation_sweeps.py
@@ -8,7 +8,7 @@ import tempfile
 models= ["minerva"]
 
 def run_sim_sweeps(sweep_file, gem5_binary, num_threads):
-  sweeps_dir = "%s/experiments/sweeps" % os.environ["SMAUG_HOME"]
+  sweeps_dir = os.path.join(os.environ["SMAUG_HOME"], "experiments/sweeps")
   sweep_generator = os.path.join(sweeps_dir, "main.py")
 
   for model in models:

--- a/.circleci/run_simulation_sweeps.py
+++ b/.circleci/run_simulation_sweeps.py
@@ -1,0 +1,40 @@
+import argparse
+import os
+import subprocess
+import six
+import shutil
+import tempfile
+
+models= ["minerva"]
+
+def run_sim_sweeps(sweep_file, gem5_binary, num_threads):
+  sweeps_dir = "%s/experiments/sweeps" % os.environ["SMAUG_HOME"]
+  sweep_generator = os.path.join(sweeps_dir, "main.py")
+
+  for model in models:
+    temp_dir = tempfile.mkdtemp(dir=os.getcwd())
+    process = subprocess.Popen([
+        "python", sweep_generator, "--model", model, "--params", sweep_file,
+        "--output", temp_dir, "--gem5-binary", gem5_binary, "--run-points",
+        "--num-threads",
+        str(num_threads)
+    ], stdout=None, stderr=subprocess.PIPE)
+    _, stderr = process.communicate()
+    assert process.returncode == 0, (
+        "Running the sweeper returned nonzero exit "
+        "code Contents of stderr:\n %s" % six.ensure_text(stderr))
+    shutil.rmtree(temp_dir)
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      "--sweep-file", type=str, help="Sweep generator input file.",
+      required=True)
+  parser.add_argument(
+      "--gem5-binary", type=str, help="gem5 binary file used for simulation.",
+      required=True)
+  parser.add_argument(
+      "--num-threads", type=int,
+      help="Number of threads to run the simulations.", default=4)
+  args = parser.parse_args()
+  run_sim_sweeps(args.sweep_file, args.gem5_binary, args.num_threads)

--- a/.circleci/sweep.json
+++ b/.circleci/sweep.json
@@ -1,0 +1,4 @@
+{
+    "num_accels": [1, 2, 4],
+    "soc_interface": ["dma", "acp"]
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -135,3 +135,5 @@ RUN git clone https://github.com/harvard-acc/smaug.git && \
     git submodule init && \
     git submodule update
 
+# More dependencies
+RUN apt-get install -y libgoogle-perftools-dev


### PR DESCRIPTION
We previously added the support in CircirCI for downloading the latest
gem5 binary from gem5-aladdin repo, but didn't actually use the
downloaded binary. This invokes the SMAUG sweep generator and runs the
generated sweeps using the downloaded gem5 binary.

We currently sweep the number of accelerators (1-4) and the SoC interface
choices (DMA or ACP). Because our current CircleCI plan only has 4GB
memory, we can only run one simulation at a time in order to not go OOM.