### PR TITLE
 operators: Clean up operator validation APIs.

### DIFF
--- a/smaug/core/operator.cpp
+++ b/smaug/core/operator.cpp
@@ -23,28 +23,4 @@ void Operator::printSummary(std::ostream& out) const {
     }
 }
 
-bool Operator::tensorsAllConstructed(
-        const std::vector<TensorBase*>& tensors) const {
-    for (auto tensor : tensors) {
-        if (!tensor || !tensor->containsData())
-            return false;
-    }
-    return true;
-}
-
-bool Operator::validateInputsOutputs() const {
-    bool success = true;
-    if (!tensorsAllConstructed(inputs)) {
-        success = false;
-        std::cerr << "[ERROR]: Inputs to " << getName()
-                  << " were not all constructed!\n";
-    }
-    if (!tensorsAllConstructed(outputs)) {
-        success = false;
-        std::cerr << "[ERROR]: Outputs to " << getName()
-                  << " were not all constructed!\n";
-    }
-    return success;
-}
-
 }  // namespace smaug

--- a/smaug/core/operator.h
+++ b/smaug/core/operator.h
@@ -40,8 +40,12 @@ class Operator {
      * All Operator subclasses must override this method.
      */
     virtual void run() = 0;
+
+    /**
+     * Returns true if the parameters/tensors of this operator are all valid.
+     */
     virtual bool validate() {
-        return validateInputsOutputs() && opType != OpType::UnknownOp;
+        return opType != OpType::UnknownOp;
     }
 
     /**
@@ -117,7 +121,6 @@ class Operator {
 
    protected:
     bool tensorsAllConstructed(const std::vector<TensorBase*>& tensors) const;
-    bool validateInputsOutputs() const;
 
     /** An ordered list of input tensors consumed by this operator.
      *

--- a/smaug/core/operator.h
+++ b/smaug/core/operator.h
@@ -120,8 +120,6 @@ class Operator {
     MemoryType getOutputsMemType() const { return outputsMemType; }
 
    protected:
-    bool tensorsAllConstructed(const std::vector<TensorBase*>& tensors) const;
-
     /** An ordered list of input tensors consumed by this operator.
      *
      * Operators may assign semantic meaning to specific input tensors at


### PR DESCRIPTION
The validateInputsOutputs only checks if the tensors have been constructed and allocated storage, but in practice, this is already handled by network_builder (and tested by network_test), and operators which override validate() currently don't call the super-method anyways. In my opinion, it's an extraneous check that we can do away with.