### PR TITLE
core: Reorganize some tiling functions for easier API reuse.

### DIFF
--- a/smaug/core/tensor_utils.cpp
+++ b/smaug/core/tensor_utils.cpp
@@ -1,15 +1,17 @@
 #include <iostream>
 
 #include "fp16.h"
-#include "smaug/core/workspace.h"
 #include "smaug/core/tensor.h"
 #include "smaug/core/tensor_utils.h"
+#include "smaug/core/workspace.h"
 #include "smaug/utility/debug_stream.h"
 
 namespace smaug {
 
 template <>
-void printTensorElement<float16>(std::ostream& os, const float16* data, int index) {
+void printTensorElement<float16>(std::ostream& os,
+                                 const float16* data,
+                                 int index) {
     os << fp16_ieee_to_fp32_value(data[index]);
 }
 
@@ -194,14 +196,51 @@ int computePaddedTileDim(int maxTileDim,
 }
 }  // namespace internal
 
-TiledTensor generateTiledTensor(Tensor* tensor,
-                                const TensorShape& tileShape,
-                                Operator* op,
-                                int fieldRows,
-                                int fieldCols,
-                                int rowStride,
-                                int colStride,
-                                PaddingType paddingType) {
+TiledTensor generateTiledTensorPerBatchNC(
+		Tensor* tensor,
+                                  const TensorShape& tileShape,
+                                  Operator* op,
+                                  bool copyData) {
+    const TensorShape& inputShape = tensor->getShape();
+    int inputSize = inputShape.storageSize();
+    int tileSize = tileShape.storageSize();
+    int numTiles = std::ceil(inputSize * 1.0 / tileSize);
+    TiledTensor tiledTensor(
+            TensorShape({ 1, numTiles }, DataLayout::NC), tensor, true);
+    int remainingSize = inputSize;
+    int srcOffset = 0;
+    for (auto tileIndex = tiledTensor.startIndex(); !tileIndex.end();
+         ++tileIndex) {
+        int currentTileSize = std::min(remainingSize, tileSize);
+        TensorShape currentShape({ 1, currentTileSize },
+                                 DataLayout::NC,
+                                 tileShape.getAlignment());
+        std::string tileName = op->getName() + ":" + tensor->getName() +
+                               "/tile:" + std::to_string((int)tileIndex);
+        Tensor* tile = new Tensor(tileName, currentShape);
+        tile->allocateStorage(tensor->getDataType());
+        tiledTensor.setTile(tileIndex, { srcOffset }, tile, copyData);
+        srcOffset += currentTileSize;
+        remainingSize -= currentTileSize;
+    }
+    op->getWorkspace()->addTiledTensor(tiledTensor);
+    dout(1) << "  Tiled Tensor " << tensor->getName() << ":\n"
+            << "    original tensor shape: " << tensor->getShape() << "\n"
+            << "    tile shape " << tileShape
+            << ", number of tiles: " << tiledTensor.size() << "\n";
+    return tiledTensor;
+}
+
+TiledTensor generateTiledTensorWithStrideAndPadding(
+        Tensor* tensor,
+        const TensorShape& tileShape,
+        Operator* op,
+        int fieldRows,
+        int fieldCols,
+        int rowStride,
+        int colStride,
+        PaddingType paddingType,
+        bool copyData) {
     const TensorShape& inputShape = tensor->getShape();
     const int ndims = inputShape.ndims();
     DataLayout layout = inputShape.getLayout();
@@ -283,12 +322,23 @@ TiledTensor generateTiledTensor(Tensor* tensor,
             }
         }
     }
+    if (copyData) {
+        tiledTensor.copyDataToAllTiles();
+    }
     op->getWorkspace()->addTiledTensor(tiledTensor);
     dout(1) << "  Tiled Tensor " << tensor->getName() << ":\n"
             << "    original tensor shape: " << tensor->getShape() << "\n"
             << "    tile shape: " << tileShape
             << ", number of tiles: " << tiledTensor.size() << "\n";
     return tiledTensor;
+}
+
+TiledTensor generateTiledTensor(Tensor* tensor,
+                                const TensorShape& tileShape,
+                                Operator* op,
+                                bool copyData) {
+    return generateTiledTensorWithStrideAndPadding(
+            tensor, tileShape, op, 0, 0, 1, 1, ValidPadding, copyData);
 }
 
 void flattenTiledTensor(TiledTensor& tiledTensor, Tensor* destTensor) {

--- a/smaug/core/tensor_utils.cpp
+++ b/smaug/core/tensor_utils.cpp
@@ -196,11 +196,10 @@ int computePaddedTileDim(int maxTileDim,
 }
 }  // namespace internal
 
-TiledTensor generateTiledTensorPerBatchNC(
-		Tensor* tensor,
-                                  const TensorShape& tileShape,
-                                  Operator* op,
-                                  bool copyData) {
+TiledTensor generateTiledTensorPerBatchNC(Tensor* tensor,
+                                          const TensorShape& tileShape,
+                                          Operator* op,
+                                          bool copyData) {
     const TensorShape& inputShape = tensor->getShape();
     int inputSize = inputShape.storageSize();
     int tileSize = tileShape.storageSize();

--- a/smaug/core/tensor_utils.h
+++ b/smaug/core/tensor_utils.h
@@ -209,9 +209,9 @@ void copyRawTensorData(
  * @param copyData Whether to copy data from the source tensor into the tiles.
  */
 TiledTensor generateTiledTensorPerBatchNC(Tensor* tensor,
-                                  const TensorShape& tileShape,
-                                  Operator* op,
-                                  bool copyData = true);
+                                          const TensorShape& tileShape,
+                                          Operator* op,
+                                          bool copyData = true);
 
 /**
  * Generates a TiledTensor from a source Tensor with the specified tile shape.

--- a/smaug/core/tensor_utils.h
+++ b/smaug/core/tensor_utils.h
@@ -6,9 +6,9 @@
 #ifndef _CORE_TENSOR_UTILS_H_
 #define _CORE_TENSOR_UTILS_H_
 
+#include <cstring>
 #include <iostream>
 #include <vector>
-#include <cstring>
 
 #include "smaug/core/tensor.h"
 
@@ -27,7 +27,9 @@ void printTensorElement(std::ostream& os, const DType* data, int index) {
 }
 
 template <>
-void printTensorElement<float16>(std::ostream& os, const float16* data, int index);
+void printTensorElement<float16>(std::ostream& os,
+                                 const float16* data,
+                                 int index);
 
 /**
  * Pretty-print a Tensor's name, shape, and contents to the provided ostream.
@@ -194,6 +196,22 @@ void copyTensorData(Tensor* dest,
 void copyRawTensorData(
         Tensor* dest, Tensor* src, int destOffset, int srcOffset, int copySize);
 
+/**
+ * Tile the provided NC Tensor per batch.
+ *
+ * The only requirement is to tile the Tensor in contiguous blocks of
+ * tileShape, without concern for strides, overlap, or padding. Thus, this is
+ * usually useful only for unary and elementwise operators.
+ *
+ * @param tensor The Tensor to tile.
+ * @param tileShape The maximum size of each tile.
+ * @param op The Operator that will be consuming this TiledTensor.
+ * @param copyData Whether to copy data from the source tensor into the tiles.
+ */
+TiledTensor generateTiledTensorPerBatchNC(Tensor* tensor,
+                                  const TensorShape& tileShape,
+                                  Operator* op,
+                                  bool copyData = true);
 
 /**
  * Generates a TiledTensor from a source Tensor with the specified tile shape.
@@ -210,39 +228,34 @@ void copyRawTensorData(
  * @param colStride The column stride of a filter applied, if any.
  * @param paddingType The type of additional zero-padding applied on the Tensor
  * by the Operator, if any.
+ * @param copyData Whether to copy data from the source tensor into the tiles.
+ */
+TiledTensor generateTiledTensorWithStrideAndPadding(
+        Tensor* tensor,
+        const TensorShape& tileShape,
+        Operator* op,
+        int fieldRows,
+        int fieldCols,
+        int rowStride,
+        int colStride,
+        PaddingType paddingType,
+        bool copyData = false);
+
+/**
+ * Generates a TiledTensor from a source Tensor.
+ *
+ * This does not support generating tiles with overlap, striding, or padding
+ * options.
+ *
+ * @param tensor The Tensor to tile.
+ * @param tileShape The maximum size of each tile.
+ * @param op The Operator that will be consuming this TiledTensor.
+ * @param copyData Whether to copy data from the source tensor into the tiles.
  */
 TiledTensor generateTiledTensor(Tensor* tensor,
                                 const TensorShape& tileShape,
                                 Operator* op,
-                                int fieldRows = 0,
-                                int fieldCols = 0,
-                                int rowStride = 1,
-                                int colStride = 1,
-                                PaddingType paddingType = ValidPadding);
-
-/**
- * A helper method to both tile a Tensor and fill the tiles with data.
- */
-TiledTensor generateTiledTensorAndCopyData(
-        Tensor* tensor,
-        const TensorShape& tileShape,
-        Operator* op,
-        int fieldRows = 0,
-        int fieldCols = 0,
-        int rowStride = 1,
-        int colStride = 1,
-        PaddingType paddingType = ValidPadding);
-
-/**
- * A helper method to both tile a Tensor and fill the tiles with data.
- */
-template <typename... Args>
-TiledTensor generateTiledTensorAndCopyData(Args&&... args) {
-    TiledTensor tiledTensor =
-            generateTiledTensor(std::forward<Args>(args)...);
-    tiledTensor.copyDataToAllTiles();
-    return tiledTensor;
-}
+                                bool copyData = false);
 
 /**
  * Copies the data from each tile in a TiledTensor into a destination Tensor as

--- a/smaug/operators/smv/smv_batch_norm_tiling.cpp
+++ b/smaug/operators/smv/smv_batch_norm_tiling.cpp
@@ -273,7 +273,8 @@ std::array<TiledTensor, 3> TilingOptimizer::doTiling(SmvBatchNormOp* op) {
             generateTiledTensor(inputs, tileConfig.inputs, op);
     // Copy data for the weight tiles since the data is read-only.
     TiledTensor tiledWeights =
-            generateTiledTensorAndCopyData(weights, tileConfig.weights, op);
+            generateTiledTensor(weights, tileConfig.weights, op);
+    tiledWeights.copyDataToAllTiles();
     TiledTensor tiledOutputs =
             generateTiledTensor(outputs, tileConfig.inputs, op);
     return { tiledInputs, tiledWeights, tiledOutputs };

--- a/smaug/operators/smv/smv_batch_norm_tiling.cpp
+++ b/smaug/operators/smv/smv_batch_norm_tiling.cpp
@@ -273,8 +273,8 @@ std::array<TiledTensor, 3> TilingOptimizer::doTiling(SmvBatchNormOp* op) {
             generateTiledTensor(inputs, tileConfig.inputs, op);
     // Copy data for the weight tiles since the data is read-only.
     TiledTensor tiledWeights =
-            generateTiledTensor(weights, tileConfig.weights, op);
-    tiledWeights.copyDataToAllTiles();
+            generateTiledTensor(weights, tileConfig.weights, 
+			        op, /* copyData */ true);
     TiledTensor tiledOutputs =
             generateTiledTensor(outputs, tileConfig.inputs, op);
     return { tiledInputs, tiledWeights, tiledOutputs };

--- a/smaug/operators/smv/smv_batch_norm_tiling_test.cpp
+++ b/smaug/operators/smv/smv_batch_norm_tiling_test.cpp
@@ -1,10 +1,10 @@
 #include "catch.hpp"
 #include "smaug/core/backend.h"
-#include "smaug/core/tensor.h"
 #include "smaug/core/smaug_test.h"
-#include "smaug/operators/smv/smv_test_common.h"
+#include "smaug/core/tensor.h"
 #include "smaug/operators/smv/smv_batch_norm_op.h"
 #include "smaug/operators/smv/smv_batch_norm_tiling.h"
+#include "smaug/operators/smv/smv_test_common.h"
 
 using namespace smaug;
 
@@ -58,8 +58,8 @@ TEST_CASE_METHOD(SmaugTest, "Post-conv bn tiling", "[smvtiling]") {
 
         SECTION("Generated tiles have correct shape and data") {
             fillTensorWithFixedData(inputs);
-            TiledTensor inputsTiles =
-                    generateTiledTensorAndCopyData(inputs, config.inputs, bnOp);
+            TiledTensor inputsTiles = generateTiledTensor(
+                    inputs, config.inputs, bnOp, /* copy_data */ true);
             REQUIRE(inputsTiles.size() == 2);
             for (auto i = inputsTiles.startIndex(); !i.end(); ++i) {
                 REQUIRE(inputsTiles[i]->getShape().dims() ==
@@ -68,16 +68,16 @@ TEST_CASE_METHOD(SmaugTest, "Post-conv bn tiling", "[smvtiling]") {
             }
 
             fillTensorWithFixedData(weights);
-            TiledTensor weightsTiles = generateTiledTensorAndCopyData(
-                    weights, config.weights, bnOp);
+            TiledTensor weightsTiles = generateTiledTensor(
+                    weights, config.weights, bnOp, /* copy_data */ true);
             REQUIRE(weightsTiles.size() == 1);
             REQUIRE(weightsTiles[0]->getShape().dims() ==
                     config.weights.dims());
             verifyTensorWithFixedData(weightsTiles[0], 0);
 
             fillTensorWithFixedData(outputs);
-            TiledTensor outputsTiles = generateTiledTensorAndCopyData(
-                    outputs, config.outputs, bnOp);
+            TiledTensor outputsTiles = generateTiledTensor(
+                    outputs, config.outputs, bnOp, /* copy_data */ true);
             REQUIRE(outputsTiles.size() == 2);
             for (auto i = outputsTiles.startIndex(); !i.end(); ++i) {
                 REQUIRE(outputsTiles[i]->getShape().dims() ==
@@ -105,8 +105,8 @@ TEST_CASE_METHOD(SmaugTest, "Post-conv bn tiling", "[smvtiling]") {
 
         SECTION("Generated tiles have correct shape and data") {
             fillTensorWithFixedData(inputs);
-            TiledTensor inputsTiles =
-                    generateTiledTensorAndCopyData(inputs, config.inputs, bnOp);
+            TiledTensor inputsTiles = generateTiledTensor(
+                    inputs, config.inputs, bnOp, /* copy_data */ true);
             REQUIRE(inputsTiles.size() == 8);
             for (auto i = inputsTiles.startIndex(); !i.end(); ++i) {
                 REQUIRE(inputsTiles[i]->getShape().dims() ==
@@ -115,16 +115,16 @@ TEST_CASE_METHOD(SmaugTest, "Post-conv bn tiling", "[smvtiling]") {
             }
 
             fillTensorWithFixedData(weights);
-            TiledTensor weightsTiles = generateTiledTensorAndCopyData(
-                    weights, config.weights, bnOp);
+            TiledTensor weightsTiles = generateTiledTensor(
+                    weights, config.weights, bnOp, /* copy_data */ true);
             REQUIRE(weightsTiles.size() == 1);
             REQUIRE(weightsTiles[0]->getShape().dims() ==
                     config.weights.dims());
             verifyTensorWithFixedData(weightsTiles[0], 0);
 
             fillTensorWithFixedData(outputs);
-            TiledTensor outputsTiles = generateTiledTensorAndCopyData(
-                    outputs, config.outputs, bnOp);
+            TiledTensor outputsTiles = generateTiledTensor(
+                    outputs, config.outputs, bnOp, /* copy_data */ true);
             REQUIRE(outputsTiles.size() == 8);
             for (auto i = outputsTiles.startIndex(); !i.end(); ++i) {
                 REQUIRE(outputsTiles[i]->getShape().dims() ==
@@ -152,8 +152,8 @@ TEST_CASE_METHOD(SmaugTest, "Post-conv bn tiling", "[smvtiling]") {
 
         SECTION("Generated tiles have correct shape and data") {
             fillTensorWithFixedData(inputs);
-            TiledTensor inputsTiles =
-                    generateTiledTensorAndCopyData(inputs, config.inputs, bnOp);
+            TiledTensor inputsTiles = generateTiledTensor(
+                    inputs, config.inputs, bnOp, /* copy_data */ true);
             REQUIRE(inputsTiles.size() == 128);
             for (auto i = inputsTiles.startIndex(); !i.end(); ++i) {
                 REQUIRE(inputsTiles[i]->getShape().dims() ==
@@ -162,16 +162,16 @@ TEST_CASE_METHOD(SmaugTest, "Post-conv bn tiling", "[smvtiling]") {
             }
 
             fillTensorWithFixedData(weights);
-            TiledTensor weightsTiles = generateTiledTensorAndCopyData(
-                    weights, config.weights, bnOp);
+            TiledTensor weightsTiles = generateTiledTensor(
+                    weights, config.weights, bnOp, /* copy_data */ true);
             REQUIRE(weightsTiles.size() == 1);
             REQUIRE(weightsTiles[0]->getShape().dims() ==
                     config.weights.dims());
             verifyTensorWithFixedData(weightsTiles[0], 0);
 
             fillTensorWithFixedData(outputs);
-            TiledTensor outputsTiles = generateTiledTensorAndCopyData(
-                    outputs, config.outputs, bnOp);
+            TiledTensor outputsTiles = generateTiledTensor(
+                    outputs, config.outputs, bnOp, /* copy_data */ true);
             REQUIRE(outputsTiles.size() == 128);
             for (auto i = outputsTiles.startIndex(); !i.end(); ++i) {
                 REQUIRE(outputsTiles[i]->getShape().dims() ==
@@ -199,8 +199,8 @@ TEST_CASE_METHOD(SmaugTest, "Post-conv bn tiling", "[smvtiling]") {
 
         SECTION("Generated tiles have correct shape and data") {
             fillTensorWithFixedData(inputs);
-            TiledTensor inputsTiles =
-                    generateTiledTensorAndCopyData(inputs, config.inputs, bnOp);
+            TiledTensor inputsTiles = generateTiledTensor(
+                    inputs, config.inputs, bnOp, /* copy_data */ true);
             REQUIRE(inputsTiles.size() == 64);
             for (auto i = inputsTiles.startIndex(); !i.end(); ++i) {
                 REQUIRE(inputsTiles[i]->getShape().dims() ==
@@ -209,16 +209,16 @@ TEST_CASE_METHOD(SmaugTest, "Post-conv bn tiling", "[smvtiling]") {
             }
 
             fillTensorWithFixedData(weights);
-            TiledTensor weightsTiles = generateTiledTensorAndCopyData(
-                    weights, config.weights, bnOp);
+            TiledTensor weightsTiles = generateTiledTensor(
+                    weights, config.weights, bnOp, /* copy_data */ true);
             REQUIRE(weightsTiles.size() == 1);
             REQUIRE(weightsTiles[0]->getShape().dims() ==
                     config.weights.dims());
             verifyTensorWithFixedData(weightsTiles[0], 0);
 
             fillTensorWithFixedData(outputs);
-            TiledTensor outputsTiles = generateTiledTensorAndCopyData(
-                    outputs, config.outputs, bnOp);
+            TiledTensor outputsTiles = generateTiledTensor(
+                    outputs, config.outputs, bnOp, /* copy_data */ true);
             REQUIRE(outputsTiles.size() == 64);
             for (auto i = outputsTiles.startIndex(); !i.end(); ++i) {
                 REQUIRE(outputsTiles[i]->getShape().dims() ==
@@ -246,8 +246,8 @@ TEST_CASE_METHOD(SmaugTest, "Post-conv bn tiling", "[smvtiling]") {
 
         SECTION("Generated tiles have correct shape and data") {
             fillTensorWithFixedData(inputs);
-            TiledTensor inputsTiles =
-                    generateTiledTensorAndCopyData(inputs, config.inputs, bnOp);
+            TiledTensor inputsTiles = generateTiledTensor(
+                    inputs, config.inputs, bnOp, /* copy_data */ true);
             REQUIRE(inputsTiles.size() == 2 * 64);
             for (auto i = inputsTiles.startIndex(); !i.end(); ++i) {
                 REQUIRE(inputsTiles[i]->getShape().dims() ==
@@ -256,16 +256,16 @@ TEST_CASE_METHOD(SmaugTest, "Post-conv bn tiling", "[smvtiling]") {
             }
 
             fillTensorWithFixedData(weights);
-            TiledTensor weightsTiles = generateTiledTensorAndCopyData(
-                    weights, config.weights, bnOp);
+            TiledTensor weightsTiles = generateTiledTensor(
+                    weights, config.weights, bnOp, /* copy_data */ true);
             REQUIRE(weightsTiles.size() == 1);
             REQUIRE(weightsTiles[0]->getShape().dims() ==
                     config.weights.dims());
             verifyTensorWithFixedData(weightsTiles[0], 0);
 
             fillTensorWithFixedData(outputs);
-            TiledTensor outputsTiles = generateTiledTensorAndCopyData(
-                    outputs, config.outputs, bnOp);
+            TiledTensor outputsTiles = generateTiledTensor(
+                    outputs, config.outputs, bnOp, /* copy_data */ true);
             REQUIRE(outputsTiles.size() == 2 * 64);
             for (auto i = outputsTiles.startIndex(); !i.end(); ++i) {
                 REQUIRE(outputsTiles[i]->getShape().dims() ==
@@ -293,8 +293,8 @@ TEST_CASE_METHOD(SmaugTest, "Post-conv bn tiling", "[smvtiling]") {
 
         SECTION("Generated tiles have correct shape and data") {
             fillTensorWithFixedData(inputs);
-            TiledTensor inputsTiles =
-                    generateTiledTensorAndCopyData(inputs, config.inputs, bnOp);
+            TiledTensor inputsTiles = generateTiledTensor(
+                    inputs, config.inputs, bnOp, /* copy_data */ true);
             REQUIRE(inputsTiles.size() == 16 * 64);
             for (auto i = inputsTiles.startIndex(); !i.end(); ++i) {
                 REQUIRE(inputsTiles[i]->getShape().dims() ==
@@ -303,16 +303,16 @@ TEST_CASE_METHOD(SmaugTest, "Post-conv bn tiling", "[smvtiling]") {
             }
 
             fillTensorWithFixedData(weights);
-            TiledTensor weightsTiles = generateTiledTensorAndCopyData(
-                    weights, config.weights, bnOp);
+            TiledTensor weightsTiles = generateTiledTensor(
+                    weights, config.weights, bnOp, /* copy_data */ true);
             REQUIRE(weightsTiles.size() == 1);
             REQUIRE(weightsTiles[0]->getShape().dims() ==
                     config.weights.dims());
             verifyTensorWithFixedData(weightsTiles[0], 0);
 
             fillTensorWithFixedData(outputs);
-            TiledTensor outputsTiles = generateTiledTensorAndCopyData(
-                    outputs, config.outputs, bnOp);
+            TiledTensor outputsTiles = generateTiledTensor(
+                    outputs, config.outputs, bnOp, /* copy_data */ true);
             REQUIRE(outputsTiles.size() == 16 * 64);
             for (auto i = outputsTiles.startIndex(); !i.end(); ++i) {
                 REQUIRE(outputsTiles[i]->getShape().dims() ==
@@ -363,8 +363,8 @@ TEST_CASE_METHOD(SmaugTest, "Post-fc bn tiling", "[smvtiling]") {
 
         SECTION("Generated tiles have correct shape and data") {
             fillTensorWithFixedData(inputs);
-            TiledTensor inputsTiles =
-                    generateTiledTensorAndCopyData(inputs, config.inputs, bnOp);
+            TiledTensor inputsTiles = generateTiledTensor(
+                    inputs, config.inputs, bnOp, /* copy_data */ true);
             REQUIRE(inputsTiles.size() == 8);
             for (auto i = inputsTiles.startIndex(); !i.end(); ++i) {
                 REQUIRE(inputsTiles[i]->getShape().dims() ==
@@ -373,8 +373,8 @@ TEST_CASE_METHOD(SmaugTest, "Post-fc bn tiling", "[smvtiling]") {
             }
 
             fillTensorWithFixedData(weights);
-            TiledTensor weightsTiles = generateTiledTensorAndCopyData(
-                    weights, config.weights, bnOp);
+            TiledTensor weightsTiles = generateTiledTensor(
+                    weights, config.weights, bnOp, /* copy_data */ true);
             REQUIRE(weightsTiles.size() == 8);
             for (auto i = weightsTiles.startIndex(); !i.end(); ++i) {
                 REQUIRE(weightsTiles[i]->getShape().dims() ==
@@ -383,8 +383,8 @@ TEST_CASE_METHOD(SmaugTest, "Post-fc bn tiling", "[smvtiling]") {
             }
 
             fillTensorWithFixedData(outputs);
-            TiledTensor outputsTiles = generateTiledTensorAndCopyData(
-                    outputs, config.outputs, bnOp);
+            TiledTensor outputsTiles = generateTiledTensor(
+                    outputs, config.outputs, bnOp, /* copy_data */ true);
             REQUIRE(outputsTiles.size() == 8);
             for (auto i = outputsTiles.startIndex(); !i.end(); ++i) {
                 REQUIRE(outputsTiles[i]->getShape().dims() ==

--- a/smaug/operators/smv/smv_convolution_tiling.cpp
+++ b/smaug/operators/smv/smv_convolution_tiling.cpp
@@ -347,17 +347,19 @@ std::array<TiledTensor, 3> TilingOptimizer::doTiling(SmvConvolutionOp* op) {
     auto kernels = op->getInput(SmvConvolutionOp::Kernels);
     auto output = op->getOutput(SmvConvolutionOp::Outputs);
     TilingConfig tileConfig = TilingOptimizer::computeBasicTileShapes(op);
-    TiledTensor tiledInputs = generateTiledTensor(input,
-                                                  tileConfig.inputs,
-                                                  op,
-                                                  op->getWeightRows(),
-                                                  op->getWeightCols(),
-                                                  op->getRowStride(),
-                                                  op->getColStride(),
-                                                  op->getPadding());
+    TiledTensor tiledInputs =
+            generateTiledTensorWithStrideAndPadding(input,
+                                                    tileConfig.inputs,
+                                                    op,
+                                                    op->getWeightRows(),
+                                                    op->getWeightCols(),
+                                                    op->getRowStride(),
+                                                    op->getColStride(),
+                                                    op->getPadding());
     // Copy data for the weight tiles since the data is read-only.
-    TiledTensor tiledWeights = generateTiledTensorAndCopyData(
-            kernels, tileConfig.weights, op);
+    TiledTensor tiledWeights =
+            generateTiledTensor(kernels, tileConfig.weights, op);
+    tiledWeights.copyDataToAllTiles();
     TiledTensor tiledOutputs;
     if (needsHwiseTiling(tileConfig.outputTilingDims)) {
         tiledOutputs = TilingOptimizer::generateRowwiseOutputTiledTensor(
@@ -368,7 +370,8 @@ std::array<TiledTensor, 3> TilingOptimizer::doTiling(SmvConvolutionOp* op) {
                 output,
                 false);
     } else {
-        tiledOutputs = generateTiledTensor(output, tileConfig.outputs, op);
+        tiledOutputs =
+                generateTiledTensor(output, tileConfig.outputs, op);
     }
     return { tiledInputs, tiledWeights, tiledOutputs };
 }

--- a/smaug/operators/smv/smv_convolution_tiling.cpp
+++ b/smaug/operators/smv/smv_convolution_tiling.cpp
@@ -358,8 +358,8 @@ std::array<TiledTensor, 3> TilingOptimizer::doTiling(SmvConvolutionOp* op) {
                                                     op->getPadding());
     // Copy data for the weight tiles since the data is read-only.
     TiledTensor tiledWeights =
-            generateTiledTensor(kernels, tileConfig.weights, op);
-    tiledWeights.copyDataToAllTiles();
+            generateTiledTensor(kernels, tileConfig.weights,
+			        op, /* copyData */ true);
     TiledTensor tiledOutputs;
     if (needsHwiseTiling(tileConfig.outputTilingDims)) {
         tiledOutputs = TilingOptimizer::generateRowwiseOutputTiledTensor(

--- a/smaug/operators/smv/smv_eltwise_add_op.cpp
+++ b/smaug/operators/smv/smv_eltwise_add_op.cpp
@@ -1,4 +1,5 @@
 #include "smaug/core/backend.h"
+#include "smaug/core/tensor_utils.h"
 #include "smaug/operators/common.h"
 #include "smaug/operators/smv/smv_eltwise_add_op.h"
 #include "smaug/operators/smv/smv_unary_op_common.h"
@@ -55,9 +56,12 @@ void SmvEltwiseAddOp::tile() {
                      inputs0->getShape().storageSize());
     TensorShape tileShape(
             { 1, maxTileSize }, DataLayout::NC, SmvBackend::Alignment);
-    tiledTensors[0] = generateTiles(inputs0, tileShape, this, false);
-    tiledTensors[1] = generateTiles(inputs1, tileShape, this, false);
-    tiledTensors[2] = generateTiles(outputs, tileShape, this, false);
+    tiledTensors[0] = generateTiledTensorPerBatchNC(
+        inputs0, tileShape, this, false);
+    tiledTensors[1] = generateTiledTensorPerBatchNC(
+        inputs1, tileShape, this, false);
+    tiledTensors[2] = generateTiledTensorPerBatchNC(
+        outputs, tileShape, this, false);
 }
 
 void SmvEltwiseAddOp::run() {

--- a/smaug/operators/smv/smv_eltwise_mul_op.cpp
+++ b/smaug/operators/smv/smv_eltwise_mul_op.cpp
@@ -1,8 +1,8 @@
+#include "smaug/operators/smv/smv_eltwise_mul_op.h"
 #include "smaug/core/backend.h"
 #include "smaug/operators/common.h"
-#include "smaug/operators/smv/smv_eltwise_mul_op.h"
-#include "smaug/operators/smv/smv_unary_op_common.h"
 #include "smaug/operators/smv/smv_kernels.h"
+#include "smaug/operators/smv/smv_unary_op_common.h"
 #include "smaug/utility/debug_stream.h"
 
 namespace smaug {
@@ -55,9 +55,12 @@ void SmvEltwiseMulOp::tile() {
                      inputs0->getShape().storageSize());
     TensorShape tileShape(
             { 1, maxTileSize }, DataLayout::NC, SmvBackend::Alignment);
-    tiledTensors[0] = generateTiles(inputs0, tileShape, this, false);
-    tiledTensors[1] = generateTiles(inputs1, tileShape, this, false);
-    tiledTensors[2] = generateTiles(outputs, tileShape, this, false);
+    tiledTensors[0] =
+            generateTiledTensorPerBatchNC(inputs0, tileShape, this, false);
+    tiledTensors[1] =
+            generateTiledTensorPerBatchNC(inputs1, tileShape, this, false);
+    tiledTensors[2] =
+            generateTiledTensorPerBatchNC(outputs, tileShape, this, false);
 }
 
 void SmvEltwiseMulOp::run() {

--- a/smaug/operators/smv/smv_greater_op.cpp
+++ b/smaug/operators/smv/smv_greater_op.cpp
@@ -1,8 +1,8 @@
+#include "smaug/operators/smv/smv_greater_op.h"
 #include "smaug/core/backend.h"
 #include "smaug/operators/common.h"
-#include "smaug/operators/smv/smv_greater_op.h"
-#include "smaug/operators/smv/smv_unary_op_common.h"
 #include "smaug/operators/smv/smv_kernels.h"
+#include "smaug/operators/smv/smv_unary_op_common.h"
 #include "smaug/utility/debug_stream.h"
 
 namespace smaug {
@@ -55,9 +55,12 @@ void SmvGreaterOp::tile() {
                      inputs0->getShape().storageSize());
     TensorShape tileShape(
             { 1, maxTileSize }, DataLayout::NC, SmvBackend::Alignment);
-    tiledTensors[0] = generateTiles(inputs0, tileShape, this, false);
-    tiledTensors[1] = generateTiles(inputs1, tileShape, this, false);
-    tiledTensors[2] = generateTiles(outputs, tileShape, this, false);
+    tiledTensors[0] =
+            generateTiledTensorPerBatchNC(inputs0, tileShape, this, false);
+    tiledTensors[1] =
+            generateTiledTensorPerBatchNC(inputs1, tileShape, this, false);
+    tiledTensors[2] =
+            generateTiledTensorPerBatchNC(outputs, tileShape, this, false);
 }
 
 void SmvGreaterOp::run() {
@@ -133,9 +136,12 @@ void SmvGreaterEqualOp::tile() {
                      inputs0->getShape().storageSize());
     TensorShape tileShape(
             { 1, maxTileSize }, DataLayout::NC, SmvBackend::Alignment);
-    tiledTensors[0] = generateTiles(inputs0, tileShape, this, false);
-    tiledTensors[1] = generateTiles(inputs1, tileShape, this, false);
-    tiledTensors[2] = generateTiles(outputs, tileShape, this, false);
+    tiledTensors[0] =
+            generateTiledTensorPerBatchNC(inputs0, tileShape, this, false);
+    tiledTensors[1] =
+            generateTiledTensorPerBatchNC(inputs1, tileShape, this, false);
+    tiledTensors[2] =
+            generateTiledTensorPerBatchNC(outputs, tileShape, this, false);
 }
 
 void SmvGreaterEqualOp::run() {

--- a/smaug/operators/smv/smv_inner_product_tiling.cpp
+++ b/smaug/operators/smv/smv_inner_product_tiling.cpp
@@ -200,12 +200,14 @@ std::array<TiledTensor, 3> TilingOptimizer::doTiling(SmvInnerProductOp* op) {
     auto kernels = op->getInput(SmvInnerProductOp::Weights);
     auto output = op->getOutput(SmvInnerProductOp::Outputs);
     TilingConfig tileConfig = TilingOptimizer::computeBasicTileShapes(op);
-    TiledTensor tiledInputs = generateTiledTensor(input, tileConfig.inputs, op);
+    TiledTensor tiledInputs =
+            generateTiledTensor(input, tileConfig.inputs, op, /* copy_data*/ false);
     // Copy data for the weight tiles since the data is read-only.
     TiledTensor tiledWeights =
-            generateTiledTensorAndCopyData(kernels, tileConfig.weights, op);
+            generateTiledTensor(kernels, tileConfig.weights, op);
+    tiledWeights.copyDataToAllTiles();
     TiledTensor tiledOutputs =
-            generateTiledTensor(output, tileConfig.outputs, op);
+            generateTiledTensor(output, tileConfig.outputs, op, /* copy_data */ false);
     return { tiledInputs, tiledWeights, tiledOutputs };
 }
 

--- a/smaug/operators/smv/smv_inner_product_tiling_test.cpp
+++ b/smaug/operators/smv/smv_inner_product_tiling_test.cpp
@@ -1,10 +1,10 @@
 #include "catch.hpp"
 #include "smaug/core/backend.h"
-#include "smaug/core/tensor.h"
 #include "smaug/core/smaug_test.h"
-#include "smaug/operators/smv/smv_test_common.h"
+#include "smaug/core/tensor.h"
 #include "smaug/operators/smv/smv_inner_product_op.h"
 #include "smaug/operators/smv/smv_inner_product_tiling.h"
+#include "smaug/operators/smv/smv_test_common.h"
 
 using namespace smaug;
 
@@ -46,15 +46,15 @@ TEST_CASE_METHOD(SmaugTest, "Basic tiling tests", "[smvtiling]") {
 
         SECTION("Generated tiles have correct shape and data") {
             fillTensorWithFixedData(inputs);
-            TiledTensor inputTiles =
-                    generateTiledTensorAndCopyData(inputs, config.inputs, fcOp);
+            TiledTensor inputTiles = generateTiledTensor(
+                    inputs, config.inputs, fcOp, /* copy_data */ true);
             REQUIRE(inputTiles.size() == 1);
             verifyTensorWithFixedData(inputTiles[0], 0);
 
             auto weights = fcOp->getInput(1);
             fillTensorWithFixedData(weights);
-            TiledTensor weightTiles = generateTiledTensorAndCopyData(
-                    weights, config.weights, fcOp);
+            TiledTensor weightTiles = generateTiledTensor(
+                    weights, config.weights, fcOp, /* copy_data */ true);
             REQUIRE(weightTiles.size() == 2);
             for (auto i = weightTiles.startIndex(); !i.end(); ++i) {
                 REQUIRE(weightTiles[i]->getShape().dims() ==
@@ -64,8 +64,8 @@ TEST_CASE_METHOD(SmaugTest, "Basic tiling tests", "[smvtiling]") {
 
             auto outputs = fcOp->getOutput(0);
             fillTensorWithFixedData(outputs);
-            TiledTensor outputTiles = generateTiledTensorAndCopyData(
-                    outputs, config.outputs, fcOp);
+            TiledTensor outputTiles = generateTiledTensor(
+                    outputs, config.outputs, fcOp, /* copy_data */ true);
             REQUIRE(outputTiles.size() == 1);
             verifyTensorWithFixedData(outputTiles[0], 0);
         }
@@ -85,20 +85,20 @@ TEST_CASE_METHOD(SmaugTest, "Basic tiling tests", "[smvtiling]") {
         allocateAllTensors<float16>(fcOp);
         TilingConfig config = TilingOptimizer::computeBasicTileShapes(fcOp);
         REQUIRE(config.inputs == inputShape);
-        REQUIRE(config.weights.dims() == std::vector<int>{ 8, 2048});
+        REQUIRE(config.weights.dims() == std::vector<int>{ 8, 2048 });
         REQUIRE(config.outputs.dims() == std::vector<int>{ 1, 128 });
 
         SECTION("Generated tiles have correct shape and data") {
             fillTensorWithFixedData(inputs);
-            TiledTensor inputTiles =
-                    generateTiledTensorAndCopyData(inputs, config.inputs, fcOp);
+            TiledTensor inputTiles = generateTiledTensor(
+                    inputs, config.inputs, fcOp, /* copy_data */ true);
             REQUIRE(inputTiles.size() == 1);
             verifyTensorWithFixedData(inputTiles[0], 0);
 
             auto weights = fcOp->getInput(1);
             fillTensorWithFixedData(weights);
-            TiledTensor weightTiles = generateTiledTensorAndCopyData(
-                    weights, config.weights, fcOp);
+            TiledTensor weightTiles = generateTiledTensor(
+                    weights, config.weights, fcOp, /* copy_data */ true);
             REQUIRE(weightTiles.size() == 16 * 2);
             for (auto i = weightTiles.startIndex(); !i.end(); ++i) {
                 REQUIRE(weightTiles[i]->getShape().dims() ==
@@ -108,8 +108,8 @@ TEST_CASE_METHOD(SmaugTest, "Basic tiling tests", "[smvtiling]") {
 
             auto outputs = fcOp->getOutput(0);
             fillTensorWithFixedData(outputs);
-            TiledTensor outputTiles = generateTiledTensorAndCopyData(
-                    outputs, config.outputs, fcOp);
+            TiledTensor outputTiles = generateTiledTensor(
+                    outputs, config.outputs, fcOp, /* copy_data */ true);
             REQUIRE(outputTiles.size() == 1);
             verifyTensorWithFixedData(outputTiles[0], 0);
         }
@@ -133,8 +133,8 @@ TEST_CASE_METHOD(SmaugTest, "Basic tiling tests", "[smvtiling]") {
 
         SECTION("Generated tiles have correct shape and data") {
             fillTensorWithFixedData(inputs);
-            TiledTensor inputTiles =
-                    generateTiledTensorAndCopyData(inputs, config.inputs, fcOp);
+            TiledTensor inputTiles = generateTiledTensor(
+                    inputs, config.inputs, fcOp, /* copy_data */ true);
             REQUIRE(inputTiles.size() == 16);
             for (auto i = inputTiles.startIndex(); !i.end(); ++i) {
                 REQUIRE(inputTiles[i]->getShape().dims() ==
@@ -144,8 +144,8 @@ TEST_CASE_METHOD(SmaugTest, "Basic tiling tests", "[smvtiling]") {
 
             auto weights = fcOp->getInput(1);
             fillTensorWithFixedData(weights);
-            TiledTensor weightTiles = generateTiledTensorAndCopyData(
-                    weights, config.weights, fcOp);
+            TiledTensor weightTiles = generateTiledTensor(
+                    weights, config.weights, fcOp, /* copy_data */ true);
             REQUIRE(weightTiles.size() == 16 * 32);
             for (auto i = weightTiles.startIndex(); !i.end(); ++i) {
                 REQUIRE(weightTiles[i]->getShape().dims() ==
@@ -155,11 +155,10 @@ TEST_CASE_METHOD(SmaugTest, "Basic tiling tests", "[smvtiling]") {
 
             auto outputs = fcOp->getOutput(0);
             fillTensorWithFixedData(outputs);
-            TiledTensor outputTiles = generateTiledTensorAndCopyData(
-                    outputs, config.outputs, fcOp);
+            TiledTensor outputTiles = generateTiledTensor(
+                    outputs, config.outputs, fcOp, /* copy_data */ true);
             REQUIRE(outputTiles.size() == 1);
             verifyTensorWithFixedData(outputTiles[0], 0);
         }
     }
 }
-

--- a/smaug/operators/smv/smv_less_op.cpp
+++ b/smaug/operators/smv/smv_less_op.cpp
@@ -1,8 +1,8 @@
+#include "smaug/operators/smv/smv_less_op.h"
 #include "smaug/core/backend.h"
 #include "smaug/operators/common.h"
-#include "smaug/operators/smv/smv_less_op.h"
-#include "smaug/operators/smv/smv_unary_op_common.h"
 #include "smaug/operators/smv/smv_kernels.h"
+#include "smaug/operators/smv/smv_unary_op_common.h"
 #include "smaug/utility/debug_stream.h"
 
 namespace smaug {
@@ -55,9 +55,12 @@ void SmvLessOp::tile() {
                      inputs0->getShape().storageSize());
     TensorShape tileShape(
             { 1, maxTileSize }, DataLayout::NC, SmvBackend::Alignment);
-    tiledTensors[0] = generateTiles(inputs0, tileShape, this, false);
-    tiledTensors[1] = generateTiles(inputs1, tileShape, this, false);
-    tiledTensors[2] = generateTiles(outputs, tileShape, this, false);
+    tiledTensors[0] =
+            generateTiledTensorPerBatchNC(inputs0, tileShape, this, false);
+    tiledTensors[1] =
+            generateTiledTensorPerBatchNC(inputs1, tileShape, this, false);
+    tiledTensors[2] =
+            generateTiledTensorPerBatchNC(outputs, tileShape, this, false);
 }
 
 void SmvLessOp::run() {
@@ -133,9 +136,12 @@ void SmvLessEqualOp::tile() {
                      inputs0->getShape().storageSize());
     TensorShape tileShape(
             { 1, maxTileSize }, DataLayout::NC, SmvBackend::Alignment);
-    tiledTensors[0] = generateTiles(inputs0, tileShape, this, false);
-    tiledTensors[1] = generateTiles(inputs1, tileShape, this, false);
-    tiledTensors[2] = generateTiles(outputs, tileShape, this, false);
+    tiledTensors[0] =
+            generateTiledTensorPerBatchNC(inputs0, tileShape, this, false);
+    tiledTensors[1] =
+            generateTiledTensorPerBatchNC(inputs1, tileShape, this, false);
+    tiledTensors[2] =
+            generateTiledTensorPerBatchNC(outputs, tileShape, this, false);
 }
 
 void SmvLessEqualOp::run() {

--- a/smaug/operators/smv/smv_pooling_tiling.cpp
+++ b/smaug/operators/smv/smv_pooling_tiling.cpp
@@ -137,8 +137,7 @@ TilingConfig TilingOptimizer::computeBasicTileShapes(SmvPoolingOp* op) {
 
     // Fill in outputs.
     std::vector<TilingConfig> fullConfigs;
-    for (auto it = inputConfigs.begin(); it != inputConfigs.end();
-         ++it) {
+    for (auto it = inputConfigs.begin(); it != inputConfigs.end(); ++it) {
         TilingConfig config(*it);
         config.outputs = outputsShape;
         config.outputs[0] = config.inputs[0];
@@ -182,15 +181,18 @@ std::array<TiledTensor, 2> TilingOptimizer::doTiling(SmvPoolingOp* op) {
     int poolRowSize, poolColSize, poolRowStride, poolColStride;
     std::tie(poolRowSize, poolColSize) = op->getPoolingSize();
     std::tie(poolRowStride, poolColStride) = op->getPoolingStride();
-    TiledTensor tiledInputs = generateTiledTensor(input,
-                                                  tileConfig.inputs,
-                                                  op,
-                                                  poolRowSize,
-                                                  poolColSize,
-                                                  poolRowStride,
-                                                  poolColStride);
-    TiledTensor tiledOutputs =
-            generateTiledTensor(output, tileConfig.outputs, op);
+    TiledTensor tiledInputs =
+            generateTiledTensorWithStrideAndPadding(input,
+                                                    tileConfig.inputs,
+                                                    op,
+                                                    poolRowSize,
+                                                    poolColSize,
+                                                    poolRowStride,
+                                                    poolColStride,
+						    ValidPadding,
+						    /* copy_data */ false);
+    TiledTensor tiledOutputs = generateTiledTensor(
+            output, tileConfig.outputs, op);
     return { tiledInputs, tiledOutputs };
 }
 

--- a/smaug/operators/smv/smv_pooling_tiling_test.cpp
+++ b/smaug/operators/smv/smv_pooling_tiling_test.cpp
@@ -1,10 +1,10 @@
 #include "catch.hpp"
 #include "smaug/core/backend.h"
-#include "smaug/core/tensor.h"
 #include "smaug/core/smaug_test.h"
-#include "smaug/operators/smv/smv_test_common.h"
+#include "smaug/core/tensor.h"
 #include "smaug/operators/smv/smv_pooling_op.h"
 #include "smaug/operators/smv/smv_pooling_tiling.h"
+#include "smaug/operators/smv/smv_test_common.h"
 
 using namespace smaug;
 
@@ -14,13 +14,17 @@ TiledTensor generateInputTiles(SmvPoolingOp* poolOp,
     int poolRowSize, poolColSize, poolRowStride, poolColStride;
     std::tie(poolRowSize, poolColSize) = poolOp->getPoolingSize();
     std::tie(poolRowStride, poolColStride) = poolOp->getPoolingStride();
-    return generateTiledTensorAndCopyData(inputs,
-                                          tileShape,
-                                          poolOp,
-                                          poolRowSize,
-                                          poolColSize,
-                                          poolRowStride,
-                                          poolColStride);
+    TiledTensor tiledTensor =
+            generateTiledTensorWithStrideAndPadding(inputs,
+                                                    tileShape,
+                                                    poolOp,
+                                                    poolRowSize,
+                                                    poolColSize,
+                                                    poolRowStride,
+                                                    poolColStride,
+                                                    PaddingType::ValidPadding,
+                                                    /* copy_data */ true);
+    return tiledTensor;
 }
 
 TEST_CASE_METHOD(SmaugTest, "SMV Pooling tiling tests", "[smvtiling]") {
@@ -68,8 +72,8 @@ TEST_CASE_METHOD(SmaugTest, "SMV Pooling tiling tests", "[smvtiling]") {
 
             auto outputs = poolOp->getOutput(0);
             fillTensorWithFixedData(outputs);
-            TiledTensor outputTiles = generateTiledTensorAndCopyData(
-                    outputs, config.outputs, poolOp);
+            TiledTensor outputTiles =
+                    generateTiledTensor(outputs, config.outputs, poolOp);
             REQUIRE(outputTiles.size() == 1);
             REQUIRE(outputTiles[0]->getShape().dims() == config.outputs.dims());
             verifyTensorWithFixedData(outputTiles[0], 0);
@@ -101,8 +105,8 @@ TEST_CASE_METHOD(SmaugTest, "SMV Pooling tiling tests", "[smvtiling]") {
 
             auto outputs = poolOp->getOutput(0);
             fillTensorWithFixedData(outputs);
-            TiledTensor outputTiles = generateTiledTensorAndCopyData(
-                    outputs, config.outputs, poolOp);
+            TiledTensor outputTiles = generateTiledTensor(
+                    outputs, config.outputs, poolOp, /* copy_data*/ true);
             REQUIRE(outputTiles.size() == 8);
             for (auto i = outputTiles.startIndex(); !i.end(); ++i) {
                 auto& testDims = outputTiles[i]->getShape().dims();
@@ -137,8 +141,8 @@ TEST_CASE_METHOD(SmaugTest, "SMV Pooling tiling tests", "[smvtiling]") {
 
                 auto outputs = poolOp->getOutput(0);
                 fillTensorWithFixedData(outputs);
-                TiledTensor outputTiles = generateTiledTensorAndCopyData(
-                        outputs, config.outputs, poolOp);
+                TiledTensor outputTiles = generateTiledTensor(
+                        outputs, config.outputs, poolOp, /* copy_data*/ true);
                 REQUIRE(outputTiles.size() == 8);
                 for (auto i = outputTiles.startIndex(); !i.end(); ++i)
                     verifyTensorWithFixedData(outputTiles[i], 0);
@@ -176,8 +180,8 @@ TEST_CASE_METHOD(SmaugTest, "SMV Pooling tiling tests", "[smvtiling]") {
 
                 auto outputs = poolOp->getOutput(0);
                 fillTensorWithFixedData(outputs);
-                TiledTensor outputTiles = generateTiledTensorAndCopyData(
-                        outputs, config.outputs, poolOp);
+                TiledTensor outputTiles = generateTiledTensor(
+                        outputs, config.outputs, poolOp, /* copy_data*/ true);
                 REQUIRE(outputTiles.size() == 12);
                 for (auto i = outputTiles.startIndex(); !i.end(); ++i) {
                     auto& testDims = outputTiles[i]->getShape().dims();
@@ -218,8 +222,8 @@ TEST_CASE_METHOD(SmaugTest, "SMV Pooling tiling tests", "[smvtiling]") {
 
             auto outputs = poolOp->getOutput(0);
             fillTensorWithFixedData(outputs);
-            TiledTensor outputTiles = generateTiledTensorAndCopyData(
-                    outputs, config.outputs, poolOp);
+            TiledTensor outputTiles = generateTiledTensor(
+                    outputs, config.outputs, poolOp, /* copy_data*/ true);
             REQUIRE(outputTiles.size() == 512);
             for (auto i = outputTiles.startIndex(); !i.end(); ++i) {
                 auto& testDims = outputTiles[i]->getShape().dims();
@@ -255,8 +259,8 @@ TEST_CASE_METHOD(SmaugTest, "SMV Pooling tiling tests", "[smvtiling]") {
 
             auto outputs = poolOp->getOutput(0);
             fillTensorWithFixedData(outputs);
-            TiledTensor outputTiles = generateTiledTensorAndCopyData(
-                    outputs, config.outputs, poolOp);
+            TiledTensor outputTiles = generateTiledTensor(
+                    outputs, config.outputs, poolOp, /* copy_data*/ true);
             REQUIRE(outputTiles.size() == 512);
             for (auto i = outputTiles.startIndex(); !i.end(); ++i) {
                 auto& testDims = outputTiles[i]->getShape().dims();
@@ -302,8 +306,8 @@ TEST_CASE_METHOD(SmaugTest, "SMV Pooling tiling tests", "[smvtiling]") {
 
                 auto outputs = poolOp->getOutput(0);
                 fillTensorWithFixedData(outputs);
-                TiledTensor outputTiles = generateTiledTensorAndCopyData(
-                        outputs, config.outputs, poolOp);
+                TiledTensor outputTiles = generateTiledTensor(
+                        outputs, config.outputs, poolOp, /* copy_data*/ true);
                 REQUIRE(outputTiles.size() == 2);
                 for (auto i = outputTiles.startIndex(); !i.end(); ++i) {
                     auto& testDims = outputTiles[i]->getShape().dims();
@@ -342,8 +346,8 @@ TEST_CASE_METHOD(SmaugTest, "SMV Pooling tiling tests", "[smvtiling]") {
 
                 auto outputs = poolOp->getOutput(0);
                 fillTensorWithFixedData(outputs);
-                TiledTensor outputTiles = generateTiledTensorAndCopyData(
-                        outputs, config.outputs, poolOp);
+                TiledTensor outputTiles = generateTiledTensor(
+                        outputs, config.outputs, poolOp, /* copy_data*/ true);
                 REQUIRE(outputTiles.size() == 8);
                 for (auto i = outputTiles.startIndex(); !i.end(); ++i) {
                     auto& testDims = outputTiles[i]->getShape().dims();
@@ -354,4 +358,3 @@ TEST_CASE_METHOD(SmaugTest, "SMV Pooling tiling tests", "[smvtiling]") {
         }
     }
 }
-

--- a/smaug/operators/smv/smv_unary_op_common.h
+++ b/smaug/operators/smv/smv_unary_op_common.h
@@ -18,23 +18,12 @@ namespace unary {
 std::pair<activation_type, activation_param_t> getActivationParams(
         UnaryOp<SmvBackend>* op);
 
-/** 
+/**
  * A generic tile dispatcher for unary operators.
- * 
+ *
  * "X" indicates that tiles can be scheduled in any order.
  */
 void runX(UnaryOp<SmvBackend>* op, TiledTensor& inputs, TiledTensor& outputs);
-
-/**
- * Tile the provided Tensor.
- *
- * This is only for unary operators. The only requirement is to tile the Tensor
- * in contiguous blocks of tileShape.
- */
-TiledTensor generateTiles(Tensor* tensor,
-                          const TensorShape& tileShape,
-                          Operator* op,
-                          bool copyData = true);
 
 std::array<TiledTensor, 2> doTiling(UnaryOp<SmvBackend>* op,
                                     bool copyData = true);

--- a/smaug/operators/smv/smv_unary_tiling_test.cpp
+++ b/smaug/operators/smv/smv_unary_tiling_test.cpp
@@ -1,9 +1,9 @@
 #include "catch.hpp"
 #include "smaug/core/backend.h"
-#include "smaug/core/tensor.h"
 #include "smaug/core/smaug_test.h"
-#include "smaug/operators/smv/smv_test_common.h"
+#include "smaug/core/tensor.h"
 #include "smaug/operators/smv/smv_relu_op.h"
+#include "smaug/operators/smv/smv_test_common.h"
 #include "smaug/operators/smv/smv_unary_op_common.h"
 
 using namespace smaug;
@@ -101,7 +101,7 @@ TEST_CASE_METHOD(SmaugTest, "SMV 4D Unary tiling tests", "[smvtiling]") {
             REQUIRE(inputTiles.size() == 2);
             for (auto i = inputTiles.startIndex(); !i.end(); ++i) {
                 auto& testDims = inputTiles[i]->getShape().dims();
-                if (i == 0 )
+                if (i == 0)
                     REQUIRE(testDims == tileDims);
                 else if (i == 1)
                     REQUIRE(testDims == std::vector<int>{ 1, 8192 });
@@ -111,7 +111,7 @@ TEST_CASE_METHOD(SmaugTest, "SMV 4D Unary tiling tests", "[smvtiling]") {
             REQUIRE(outputTiles.size() == 2);
             for (auto i = outputTiles.startIndex(); !i.end(); ++i) {
                 auto& testDims = outputTiles[i]->getShape().dims();
-                if (i == 0 )
+                if (i == 0)
                     REQUIRE(testDims == tileDims);
                 else if (i == 1)
                     REQUIRE(testDims == std::vector<int>{ 1, 8192 });
@@ -198,7 +198,7 @@ TEST_CASE_METHOD(SmaugTest, "SMV 2D Unary tiling tests", "[smvtiling]") {
             REQUIRE(inputTiles.size() == 2);
             for (auto i = inputTiles.startIndex(); !i.end(); ++i) {
                 auto& testDims = inputTiles[i]->getShape().dims();
-                if (i == 0 )
+                if (i == 0)
                     REQUIRE(testDims == tileDims);
                 else if (i == 1)
                     REQUIRE(testDims == std::vector<int>{ 1, 8192 });
@@ -208,7 +208,7 @@ TEST_CASE_METHOD(SmaugTest, "SMV 2D Unary tiling tests", "[smvtiling]") {
             REQUIRE(outputTiles.size() == 2);
             for (auto i = outputTiles.startIndex(); !i.end(); ++i) {
                 auto& testDims = outputTiles[i]->getShape().dims();
-                if (i == 0 )
+                if (i == 0)
                     REQUIRE(testDims == tileDims);
                 else if (i == 1)
                     REQUIRE(testDims == std::vector<int>{ 1, 8192 });
@@ -217,4 +217,3 @@ TEST_CASE_METHOD(SmaugTest, "SMV 2D Unary tiling tests", "[smvtiling]") {
         }
     }
 }
-


### PR DESCRIPTION
The goal is to simplify the tiling APIs, rename them to be more clear,
and remove redundant functions.

* The generateTiledTensorAndCopyData function has been deleted.
* Some unary/elementwise tiling functions are moved to tensor_utils.h.
* generateTiledTensor renamed to
  generateTiledTensorWithStrideAndPadding. A convenience function that
  takes no stride or padding parameters is also provided.