### PR TITLE
backend: Add initGlobals() for ReferenceBackend too.

### DIFF
--- a/smaug/core/backend.h
+++ b/smaug/core/backend.h
@@ -91,6 +91,10 @@ class ReferenceBackend {
     static const std::string Name;
     static const DataLayout DefaultInputDataLayout = DataLayout::NCHW;
 
+    static int SpadSize() { return 0; }
+    static void initGlobals() {}
+    static void freeGlobals() {}
+
     DECL_CREATE_OP(ConvolutionOp);
     DECL_CREATE_OP(DataOp);
     DECL_CREATE_OP(DepthwiseConvolutionOp);

--- a/smaug/smaug.cpp
+++ b/smaug/smaug.cpp
@@ -150,6 +150,7 @@ int main(int argc, char* argv[]) {
     Workspace* workspace = new Workspace();
     Network* network =
             buildNetwork(modelTopo, modelParams, sampling, workspace);
+    ReferenceBackend::initGlobals();
     SmvBackend::initGlobals();
 
     if (dumpGraph)
@@ -187,6 +188,7 @@ int main(int argc, char* argv[]) {
 
     delete network;
     delete workspace;
+    ReferenceBackend::freeGlobals();
     SmvBackend::freeGlobals();
 
     return 0;


### PR DESCRIPTION
This makes all the backends consistent, so it's easier to explain and
add global hooks for the tutorial.