### PR TITLE
Add warning about parallel builds potentially causing OOM.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,13 @@ cd LLVM-Tracer && git pull origin master && cd ..
 cd smaug && git pull origin master && git submodule update --init --recursive && cd ..
 ```
 # Building #
-We need to build gem5-Aladdin:
+We need to build gem5-Aladdin. The `-j` parameter controls how many CPUs are
+used. Increase this value to speed up the build, but keep in mind that you may
+run out of memory before you run out of CPUs.
 
 ```bash
 cd /workspace/gem5-aladdin
-python2.7 `which scons` build/X86/gem5.opt PROTOCOL=MESI_Two_Level_aladdin -j8
+python2.7 `which scons` build/X86/gem5.opt PROTOCOL=MESI_Two_Level_aladdin -j2
 ```
 
 And then SMAUG:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ cd smaug && git pull origin master && git submodule update --init --recursive &&
 # Building #
 We need to build gem5-Aladdin. The `-j` parameter controls how many CPUs are
 used. Increase this value to speed up the build, but keep in mind that you may
-run out of memory before you run out of CPUs.
+run out of memory before you run out of CPUs. Running out of memory or disk space
+can cause mysterious build failures.
 
 ```bash
 cd /workspace/gem5-aladdin


### PR DESCRIPTION
To prevent OOM, drop the default recommended build parallelism to 2
cores.