### PR TITLE
docs: Add documentation for writing the HW-accelerator operator.

### DIFF
--- a/docs/source/Doxyfile
+++ b/docs/source/Doxyfile
@@ -735,7 +735,7 @@ FILE_VERSION_FILTER    =
 # DoxygenLayout.xml, doxygen will parse it automatically even if the LAYOUT_FILE
 # tag is left empty.
 
-LAYOUT_FILE            = DoxygenLayout.xml
+LAYOUT_FILE            = source/DoxygenLayout.xml
 
 # The CITE_BIB_FILES tag can be used to specify one or more bib files containing
 # the reference definitions. This must be a list of .bib files. The .bib

--- a/docs/source/intro.dox
+++ b/docs/source/intro.dox
@@ -485,10 +485,10 @@ tiling there is - no need to consider data reuse, striding, etc. We simply need
 to break up the two input tensors and output tensor into equal sized pieces
 which maximize the use of the local scratchpads. This can be accomplished with
 just a few lines of code in `my_custom_operator.h` by overriding the `tile()`
-function and calling the smaug::generateTiledTensorSimple function. The result
-will be an array of TiledTensor objects. A TiledTensor represents a spatially
-ordered collection of Tensor objects, each containing a copy of a slice of data
-from an underlying Tensor.
+function and calling the smaug::generateTiledTensorPerBatchNC function. The
+result will be an array of TiledTensor objects. A TiledTensor represents a
+spatially ordered collection of Tensor objects, each containing a copy of a
+slice of data from an underlying Tensor.
 
 \code
 #include <array>

--- a/docs/source/intro.dox
+++ b/docs/source/intro.dox
@@ -3,6 +3,7 @@ namespace smaug {
   ***********************************************************************
   ***********************************************************************
 \mainpage The SMAUG C++ API
+
 \section Introduction
 
 SMAUG is a deep learning framework that enables end-to-end simulation of DL
@@ -70,6 +71,8 @@ output tensor) is written either to a proto, a file, or stdout.
 
 \page custom_operator Building a custom operator
 
+\tableofcontents
+
 In this document, we will describe how to build a custom operator with a custom
 hardware accelerator model implementing the logic. Our custom operator will
 perform an element-wise add of two tensors.
@@ -89,12 +92,12 @@ and more.  SMAUG ships with two backends:
   models of accelerators with 8-wide 16-bit vectorized datapaths. The SIMD
   datapaths require data to be properly aligned first.
 
-Backends are classes comprised purely of static functions and variables. They
-are defined in core/backend.h and core/backend.cpp. Backend classes are used
-as template parameters to Operator subclasses, so they must be statically
-interchangeable. Thus, all backend definitions must statically define the same
-set of functions and variables, which means that they must also support every
-operator type.
+In SMAUG, a Backend is represented as a class comprised purely of static
+functions and variables. They are defined in core/backend.h and
+core/backend.cpp. Backend classes are used as template parameters to Operator
+subclasses, so they must be statically interchangeable. Thus, all backend
+definitions must statically define the same set of functions and variables,
+which means that they must also support every operator type.
 
 After building your custom Operator, you will need to include and register the
 new operator in those files. We will discuss this more once we get to that
@@ -257,7 +260,7 @@ There are several common properties to validate:
 1. Tensor shapes.
 2. Data layout. The operator must support the order of the dimensions in which
    the elements of the tensor are arranged.
-3. Data type. The operator implementation (which represents a hardware model) 
+3. Data type. The operator implementation (which represents a hardware model)
    must have explicit support for whatever data types are desired.
 
 In our example, an elementwise addition requires that the two input tensors be
@@ -279,7 +282,7 @@ bool validate() override {
 \endcode
 
 Now, we can write the `run` function which implements the operator's function
-itself. 
+itself.
 
 \code
 
@@ -301,7 +304,7 @@ void run() override {
   float* input1Data = input1->data<float>();
   float* outputData = output->data<float>();
 
-  elementwise_add(input0Data, input1Data, output, output.getShape().size());
+  elementwise_add(input0Data, input1Data, outputData, output.getShape().size());
 }
 \endcode
 
@@ -325,7 +328,7 @@ TEST_CASE_METHOD(SmaugTest, MyCustomOperator) {
   // DataLayout::NC is a simple 2D layout, where N = batches and C = a column
   // of data.
   TensorShape shape(1, 10, DataLayout::NC);
-  Tensor* input0 = new Tensor("tensor", shape);
+  Tensor* input0 = new Tensor("tensor0", shape);
   // Allocate the memory for a 1x10 array of floats.
   input0->allocateStorage<float>();
   // Add some testing data.
@@ -333,7 +336,7 @@ TEST_CASE_METHOD(SmaugTest, MyCustomOperator) {
   workspace()->addTensor(input0);
 
   // Repeat this for a second input tensor.
-  Tensor* input1 = new Tensor("tensor", shape);
+  Tensor* input1 = new Tensor("tensor1", shape);
   input1->allocateStorage<float>();
   input1->fillData<float>({2,3,4,5,6,7,8,9,10,11});
   workspace()->addTensor(input1);
@@ -346,15 +349,15 @@ TEST_CASE_METHOD(SmaugTest, MyCustomOperator) {
   op->createAllTensors();
   // Allocates memory for all the output tensors created by createAllTensors.
   allocateAllTensors(op);
-  
+
   op->run();
 
   // Compare the output of the operator against expected values.
-  std::vector<float> expectedOutput = {3,5,7,9,11,13,15,17,19,21};
+  std::vector<float> expected_output = {3,5,7,9,11,13,15,17,19,21};
   Tensor* output = op->getOutput(TestOp::kOutput);
   // This performs an approximate comparison between the tensor's output and
   // the expected values.
-  verifyOutputs(output, expectedOutput);
+  verifyOutputs(output, expected_output);
 }
 
 \endcode
@@ -365,7 +368,369 @@ unit tests with `make tests` and run
 
 \subsection hw_implementation Hardware-accelerated implementation
 
-\section try_it_out Try it out
+Now that our software-only implementation is working, we are going to adapt it
+to serve as an Aladdin model for a hardware accelerator. This is a multi-step
+process:
+
+1. Select the design parameters for your accelerator memory system. In
+   particular, how much local scratchpad space will the accelerator have to
+   work with?
+2. Based on the answer to #1, tile your input and output tensors so that they
+   fit within the allocated scratchpad space.
+3. Write a scheduler function to iterate over each of the tiles, copying data
+   into/out of the local accelerator scratchpad space, and running the operator
+   function. This is also commonly known as writing a loop nest.
+4. Use the provided gem5-Aladdin APIs to copy data and invoke the kernel
+   function, so that during simulation, the simulator will invoke the Aladdin
+   accelerator instead of running the function on the CPU.
+5. Adapt the accelerated function (also called the kernel function) so that it
+   can be traced by LLVM-Tracer, the LLVM-based instrumentation tool that
+   generates the Aladdin dynamic trace.
+
+\subsubsection design Accelerator design parameters
+
+Accelerators have a limited amount of local memory that can be directly
+accessed. When offloading work to an accelerator, any data it needs must be
+copied into this local memory first before computation can begin. If the input
+data is larger than this local memory, that data must be tiled into smaller
+pieces that can fit.  How much memory to allocate is a design tradeoff between
+performance and hardware cost. This is a tradeoff that SMAUG can help
+researchers investigate for a particular workload.
+
+A piece of accelerator-local memory is represented in SMAUG as a global array
+that is only accessed within the accelerated function. These are typically
+declared under the appropriate namespaces in backend.h and defined in
+backend.cpp. For example, the SMV backend has three scratchpads (`spad0`,
+`spad1`, and `spad2`). `spad0` and `spad1` are typically used for inputs, while
+`spad2` is used for outputs, but this is merely a convention.
+
+For our custom operator, let's add two scratchpads to the Reference backend.
+Open up backend.cpp and add two array definitions as shown below:
+
+\code
+namespace ref {
+// This is all existing code...
+const unsigned kConvolutionHw = 0x0001;
+const unsigned kInnerProductHw = 0x0002;
+const unsigned kEltwiseOpHw = 0x0003;
+const unsigned kBatchNormHw = 0x0004;
+const unsigned kPoolingHw = 0x0005;
+
+// Define our new scratchpads here.
+int kSpadSize;
+float* spad0;
+float* spad1;
+
+// Add a unique ID for our accelerator HW. This will be used to invoke the
+// accelerator during simulation.
+const unsigned kMyCustomOperatorHw = 0x00006;
+}  // namespace ref
+\endcode
+
+Then, open up backend.h and add extern declarations for them:
+
+\code
+namespace ref {
+// This is all existing code...
+extern const unsigned kConvolutionHw;
+extern const unsigned kInnerProductHw;
+extern const unsigned kEltwiseOpHw;
+extern const unsigned kBatchNormHw;
+extern const unsigned kPoolingHw;
+
+// Declare our two new global arrays and accelerator IDs here.
+extern int kSpadSize;
+extern float* spad0;
+extern float* spad1;
+extern const unsigned kMyCustomOperatorHw;
+}  // namespace ref
+\endcode
+
+We need to allocate memory for these new arrays before they can be used. By
+this point, you should have picked a scratchpad size. Let's say you picked
+32KB. In backend.h, modify `ReferenceBackend` like so:
+
+\code
+class ReferenceBackend {
+  static int SpadSize() { return ref::kSpadSize; }
+  static void initGlobals() {
+    ref::kSpadSize = 32*1024;  // Replace with your actual value.
+    ref::spad0 = (float*) malloc_aligned(ref::kSpadSize);
+    ref::spad1 = (float*) malloc_aligned(ref::kSpadSize);
+  }
+  static void freeGlobals() {
+    free(ref::spad0);
+    free(ref::spad1);
+  }
+}
+\endcode
+
+Your accelerator-local scratchpads have now been correctly configured. We will
+modify our kernel function to use these shortly.
+
+\subsubsection tiling Tile your Tensors
+
+Writing logic to correctly tile your tensors can be tricky. There are lots of
+corner cases and special features of the data that must be taken into account
+so that the accelerator can still compute the correct output with partial data.
+To ease this, SMAUG provides a library of useful tiling functionality that you
+can reuse. When that library is insufficient, you can refer to the existing
+tiling optimizers (e.g. for SMV convolution) to get started on more complex
+tiling scenarios.
+
+Fortunately, tiling a tensor for an elementwise operator is the easiest kind of
+tiling there is - no need to consider data reuse, striding, etc. We simply need
+to break up the two input tensors and output tensor into equal sized pieces
+which maximize the use of the local scratchpads. This can be accomplished with
+just a few lines of code in `my_custom_operator.h` by overriding the `tile()`
+function and calling the smaug::generateTiledTensorSimple function. The result
+will be an array of TiledTensor objects. A TiledTensor represents a spatially
+ordered collection of Tensor objects, each containing a copy of a slice of data
+from an underlying Tensor.
+
+\code
+#include <array>
+#include "core/tensor_utils.h"
+
+class MyCustomOperator {
+ /* Existing code... */
+ public:
+  void tile() override {
+    auto inputs0 = getInput(kInput0);
+    auto inputs1 = getInput(kInput1);
+    auto outputs = getOutput(kOutput);
+    // The simplest tiling strategy is to tile per batch. Each tile will have a
+    // size of at most 1 x maxTileSize.
+    int maxTileSize =
+            std::min(ReferenceBackend::SpadSize() / inputs0->getDataTypeSize(),
+                      inputs0->getShape().storageSize());
+    TensorShape tileShape(
+             { 1, maxTileSize }, DataLayout::NC, ReferenceBackend::Alignment);
+    // The final bool parameter specifies whether to copy the data from the
+    // source tensor into each of its tiles. Obivously, we want to do this for the
+    // input tensors, but the output tensor is empty, so there's no need to
+    // waste time on that.
+    tiledTensors[0] = generateTiledTensorPerBatchNC(inputs0, tileShape, this, true);
+    tiledTensors[1] = generateTiledTensorPerBatchNC(inputs1, tileShape, this, true);
+    tiledTensors[2] = generateTiledTensorPerBatchNC(outputs, tileShape, this, false);
+  }
+
+ private:
+  // Because tensor tiling is done at the start of the program (before the
+  // operator starts running), these tiles need to be stored in memory for use
+  // later.
+  std::array<TiledTensor, 3> tiledTensors;
+}
+\endcode
+
+\subsubsection executor Modify run() to loop over all our tiles
+
+This part is straightforward. Iterate over each of the tensor tiles and run the
+`elementwise_add` function on their contents. Finally, flatten the tiled output
+tensor back into a single one. Since this is an elementwise operation, there is no
+need to consider data reuse, so a simple for loop will do. For more complex
+operators in which data reuse is a critical factor to optimize for, changing
+the order of iteration along the dimensions may greatly affect performance.
+
+\code
+void run() override {
+  TiledTensor& input0 = tiledTensors[kInput0];
+  TiledTensor& input1 = tiledTensors[kInput1];
+  TiledTensor& output = tiledTensors[kOutput];
+
+  for (int i = 0; i < input0.size(); i++) {
+    Tensor* input0Tile = input0.getTileWithData(i);
+    Tensor* input1Tile = input1.getTileWithData(i);
+    Tensor* outputTile = output.getTileWithData(i);
+
+    // Get handles to the actual underlying data storage. This performs a
+    // dynamic_cast to the specified data type, which we verified is safe inside
+    // validate().
+    float* input0Data = input0Tile->data<float>();
+    float* input1Data = input1Tile->data<float>();
+    float* outputData = outputTile->data<float>();
+    elementwise_add(input0Data, input1Data, outputData, outputTile.getShape().size());
+  }
+  // The results of the elementwise_add are stored in the tiled tensor. We need
+  // to merge the data from the individual tiles back into a single contiguous
+  // Tensor.
+  flattenTiledTensor(tiledTensors[kOutput], outputs);
+}
+\endcode
+
+As usual, let's add a unit test to verify that this implementation is correct.
+We need to ensure that our inputs are larger than the scratchpads we created in
+order for tiling to make any meaningful change. Add this code to your existing
+unit test.
+
+\code
+// A function to fill the tensor with a sequence of monotonically increasing
+// data, starting from 0. Note that this is ONLY advised for elementwise/unary
+// operators in which we don't care about data in specific dimensions.
+void fillTensorWithSequentialFloat32Data(Tensor* tensor) {
+  float32* data = tensor->data<float>();
+  for (int i = 0; i < tensor->getShape().getStorageSize(); i++) {
+    data[i] = i;
+  }
+}
+
+TEST_CASE_METHOD(SmaugTest, MyCustomOperatorWithTiling) {
+  // With float32 elements, this will occupy 128KB, which should create four
+  // tiles per tensor.
+  TensorShape shape(8, 4096, DataLayout::NC);
+  Tensor* input0 = new Tensor("tensor0", shape);
+  Tensor* input1 = new Tensor("tensor1", shape);
+  workspace()->addTensor(input0);
+  workspace()->addTensor(input1);
+
+  // Create the operator and fill it with our tensors.
+  using TestOp = MyCustomOperator<ReferenceBackend>;
+  auto op = new TestOp("eltwise_add", workspace());
+  op->setInput(input0, TestOp::kInputs0);
+  op->setInput(input1, TestOp::kInputs1);
+  // This will handle creating/allocating storage/filling data into all the
+  // input tensors.
+  createAndFillTensorsWithData(op, &fillTensorWithSequentialFloat32Data);
+  // Compute the expected output.
+  std::vector<float> expected_output(8*4096, 0);
+  for (int i = 0; i < expected_output.size(); i++) {
+    expected_output[i] = 2*i;
+  }
+
+  op->tile();
+  op->run();
+
+  Tensor* output = op->getOutput(kOutput);
+  verifyOutputs(output, expected_output);
+}
+\endcode
+
+\subsubsection gem5_aladdin_apis Use gem5-Aladdin APIs to copy data and invoke the kernel
+
+From the perspective of the `elementwise_add` function, we've been writing our
+code as if it could directly access the contents of the `input0`, `input1`, and
+`output` arrays. These are pointers into *host* memory.  But if it's
+representing a block of hardware, and the hardware can only access local
+scratchpads, we need to copy the contents of the host memory into the
+scratchpads. In gem5-Aladdin, this is accomplished with special functions:
+`dmaLoad` and `dmaStore`. They work just like regular calls to `memcpy`,
+except LLVM-Tracer will recognize this call as a special function call and have
+Aladdin handle it appropriately. This is handled as follows:
+
+\code
+// By convention, we prefix all pointers into host memory with "host_".
+void elementwise_add(float* host_input0, 
+                     float* host_input1, 
+                     float* host_output, 
+                     float* spad0, 
+                     float* spad1, 
+                     int size) {
+  // Copy input data from host_inputN to spadN. The first argument to dmaLoad
+  // or dmaStore is always the destination.
+  dmaLoad(spad0, host_input0, size);
+  dmaLoad(spad1, host_input1, size);
+  for (int i = 0; i < size; i++) {
+    // Accumulate the data from spad0 into spad1.
+    // NOTE: This could be optimized more if we had three scratchpads instead
+    // of two. This would be a great exercise for the reader :)
+    spad1[i] += spad0[i];
+  }
+  // Copy output data from spad1 back to the host.
+  dmaStore(host_output, spad1, size);
+}
+\endcode
+
+Next, for simulation, we need to set up a TLB page mapping for all host
+memory accessed by the accelerator, so that the `dmaLoad`/`dmaStore` functions
+can load the correct data into the scratchpads. This is done with the
+`mapArrayToAccelerator` API.
+
+Finally, we need to update the call to `elementwise_add` and wrap it with the
+`invokeKernel` function, so that in simulation, gem5-Aladdin will
+know to fire up the hardware accelerator model instead of just running the
+kernel function on the CPU.
+
+\code
+#include "smaug/operators/common.h"
+
+void run() override {
+  TiledTensor& input0 = tiledTensors[kInput0];
+  TiledTensor& input1 = tiledTensors[kInput1];
+  TiledTensor& output = tiledTensors[kOutput];
+
+  for (int i = 0; i < input0.size(); i++) {
+    Tensor* input0Tile = input0.getTileWithData(i);
+    Tensor* input1Tile = input1.getTileWithData(i);
+    Tensor* outputTile = output.getTileWithData(i);
+
+    // Get handles to the actual underlying data storage. This performs a
+    // dynamic_cast to the specified data type, which we verified is safe inside
+    // validate().
+    float* input0Data = input0Tile->data<float>();
+    float* input1Data = input1Tile->data<float>();
+    float* outputData = outputTile->data<float>();
+    input size = outputTile.getShape().size();
+
+    // Set up the TLB mappings.
+    mapArrayToAccelerator(
+            ref::kMyCustomOperatorHw,  // The accelerator ID this TLB mapping is for.
+            "host_input0",             // The name of the function argument in the kernel function.
+            input0Data,                // The pointer to the data.
+            size                       // The size of the TLB mapping
+   );
+    mapArrayToAccelerator(
+            ref::kMyCustomOperatorHw, "host_input1"
+            input1Data, size);
+    mapArrayToAccelerator(
+            ref::kMyCustomOperatorHw, "host_output"
+            outputData, size);
+
+
+    // Wrap the call to elementwise_add with invokeKernel.
+    invokeKernel(ref::kMyCustomOperatorHw,  // our accelerator ID
+                 elementwise_add, // if not simulating, the function to call
+                 // All of the function call arguments.
+                 input0Data,
+                 input1Data,
+                 outputData,
+                 ref::spad0,
+                 ref::spad1,
+                 outputTile.getShape().size());
+  }
+  // The results of the elementwise_add are stored in the tiled tensor. We need
+  // to merge the data from the individual tiles back into a single contiguous
+  // Tensor.
+  flattenTiledTensor(tiledTensors[kOutput], outputs);
+}
+\endcode
+
+\subsubsection llvm_tracer Make the kernel function traceable with LLVM-Tracer
+
+LLVM-Tracer is the instrumentation tool that we will use to generate a dynamic
+execution trace for Aladdin to consume.  It is only compatible with
+instrumenting C code, not C++, but it can ignore any code with C++ linkage that
+it sees. This allows us to write in C++ for the vast majority of our code,
+dropping down into C only for the few kernel functions representing the
+hardware accelerators.
+
+Adapt our code for use with LLVM-Tracer is simple: just surround the kernel
+function in an `extern "C"` block.
+
+\code
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void elementwise_add(/*...*/) { /* code ... */ }
+
+#ifdef __cplusplus
+}
+#endif
+\endcode
+
+Build your code, make sure it all compiles, and voila! We are ready to generate
+our trace, set up the simulator configuration files, and start simulating our
+first operator!
 
 \page tiling_optimizer Building a custom tiling optimizer
 

--- a/docs/source/intro.dox
+++ b/docs/source/intro.dox
@@ -405,7 +405,9 @@ backend.cpp. For example, the SMV backend has three scratchpads (`spad0`,
 `spad2` is used for outputs, but this is merely a convention.
 
 For our custom operator, let's add two scratchpads to the Reference backend.
-Open up backend.cpp and add two array definitions as shown below:
+Open up backend.cpp and add two array definitions as shown below. Also, add
+a unique integer ID for this custom operator. We'll use it later when invoking
+the accelerator in simulation.
 
 \code
 namespace ref {


### PR DESCRIPTION
This goes through all the steps:

1. Creating scratchpads for local use.
2. Tiling tensors with the tiling library functions.
3. Writing a loop nest.
4. Modifying code to work with gem5-aladdin APIs.
5. Modifying code for LLVM-Tracer.

This does not include instructions for actually running a simulation.
That's more broadly useful information which should go somewhere else
(maybe on the Python side).