### PR TITLE
docs: Add a few RST files for tutorials on the Python side.

### DIFF
--- a/docs/source/add_python_operator.rst
+++ b/docs/source/add_python_operator.rst
@@ -1,4 +1,4 @@
-Adding an new operator
-======================
+Adding a new operator
+=====================
 
 There are a few steps to add a new operator on the python side.

--- a/docs/source/add_python_operator.rst
+++ b/docs/source/add_python_operator.rst
@@ -1,4 +1,4 @@
-Adding an new operator on the Python side
-=========================================
+Adding an new operator
+======================
 
 There are a few steps to add a new operator on the python side.

--- a/docs/source/add_python_operator.rst
+++ b/docs/source/add_python_operator.rst
@@ -1,0 +1,4 @@
+Adding an new operator on the Python side
+=========================================
+
+There are a few steps to add a new operator on the python side.

--- a/docs/source/build_python_model.rst
+++ b/docs/source/build_python_model.rst
@@ -1,0 +1,4 @@
+Build a SMAUG model with Python API
+===================================
+
+Building a model is quite easy in SMAUG.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,18 +8,17 @@ SMAUG DOCUMENTATION
 SMAUG is a deep learning framework that enables end-to-end simulation of DL models on custom SoCs with a variety of hardware accelerators.
 
 .. toctree::
-   :maxdepth: 1
-   :caption: Python API
+   :maxdepth: 2
+   :caption: Python API and tutorials
 
-   smaug
-   nn
-   math
-   tensor
+   python_api
+   python_tutorials
 
-C++ API
--------
 
-* `C++ API <doxygen_html/index.html>`_
+C++ API and tutorials
+---------------------
+
+* `C++ docs link <doxygen_html/index.html>`_
 
 
 Indices and tables

--- a/docs/source/python_api.rst
+++ b/docs/source/python_api.rst
@@ -1,0 +1,11 @@
+Python API
+==========
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Python API
+
+   smaug
+   nn
+   math
+   tensor

--- a/docs/source/python_tutorials.rst
+++ b/docs/source/python_tutorials.rst
@@ -1,0 +1,9 @@
+Tutorials
+=========
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Tutorials
+
+   build_python_model
+   add_python_operator


### PR DESCRIPTION
This adds two placeholders for Python side tutorials.

1. Building a new model with Python APIs.
2. Adding a new Python operator.