### PR TITLE
docs: Add text to expose new operator in the smaug module.

### DIFF
--- a/docs/source/add_python_operator.rst
+++ b/docs/source/add_python_operator.rst
@@ -60,7 +60,18 @@ returns a list of tensors, but in our case, we have only one, so to simplify
 our API, we just return the first element.  There are other optional parameters
 to :func:`common.add_node`, but they aren't needed in this basic scenario.
 
-And that's it! You're now ready to use this operator in a new model.
+The final step is to expose this operator at the global :mod:`smaug` module
+level. Open up :file:`smaug/__init__.py` and add the following line:
+
+.. code-block:: python
+
+   from smaug.python.ops import my_custom_operator
+
+And that's it! You're now ready to use this new operator in a new model. Users
+will refer to it as :code:`smaug.my_custom_operator.my_custom_operator`.
+Obviously, the name for this small example is quite repetitive and
+uninformative, but in practice, you would use a more descriptive module
+and operator name.
 
 Adding an operator with additional parameters
 ---------------------------------------------

--- a/docs/source/add_python_operator.rst
+++ b/docs/source/add_python_operator.rst
@@ -60,7 +60,7 @@ returns a list of tensors, but in our case, we have only one, so to simplify
 our API, we just return the first element.  There are other optional parameters
 to :func:`common.add_node`, but they aren't needed in this basic scenario.
 
-The final step is to expose this operator at the global :mod:`smaug` module
+The final step is to expose this operator at the global :py:mod:`smaug` module
 level. Open up :file:`smaug/__init__.py` and add the following line:
 
 .. code-block:: python

--- a/docs/source/smaug.rst
+++ b/docs/source/smaug.rst
@@ -2,6 +2,7 @@ smaug
 =====
 .. currentmodule:: smaug
 
+.. automodule:: smaug
 .. autoclass:: Graph
    :members:
    :undoc-members:

--- a/smaug/__init__.py
+++ b/smaug/__init__.py
@@ -1,3 +1,9 @@
+"""Top level SMAUG module.
+
+All operators and core data structures should be imported either directly here
+or under a submodule.
+"""
+
 from smaug.core.types_pb2 import *
 
 from smaug.python.ops import math_ops as math
@@ -9,3 +15,7 @@ from smaug.python.ops.data_op import input_data
 from smaug.python.graph import Graph
 from smaug.python.tensor import Tensor
 from smaug.python.node import Node
+
+def _autodoc_for_module():
+  """Ensures that the top-level SMAUG module gets an autodoc link."""
+  pass


### PR DESCRIPTION
The last step of adding a new operator is to import it into the top level
smaug module. Getting Sphinx to generate a link to the smaug autodoc
section required adding additional docstrings and a dummy function
(which isn't displayed anywhere on the documentation site).