### PR TITLE
docs: Add a few cosmetics on the tree structure.

### DIFF
--- a/docs/source/cpp_docs.rst
+++ b/docs/source/cpp_docs.rst
@@ -1,0 +1,5 @@
+C++ API and Tutorials
+=====================
+
+* `C++ docs link <doxygen_html/index.html>`_
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ SMAUG DOCUMENTATION
 SMAUG is a deep learning framework that enables end-to-end simulation of DL models on custom SoCs with a variety of hardware accelerators.
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 2
    :caption: Python API and tutorials
 
    python_api

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,18 +8,17 @@ SMAUG DOCUMENTATION
 SMAUG is a deep learning framework that enables end-to-end simulation of DL models on custom SoCs with a variety of hardware accelerators.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
    :caption: Python API and tutorials
 
    python_api
    python_tutorials
 
+.. toctree::
+   :maxdepth: 1
+   :caption: C++ docs
 
-C++ API and tutorials
----------------------
-
-* `C++ docs link <doxygen_html/index.html>`_
-
+   cpp_docs
 
 Indices and tables
 ==================

--- a/docs/source/python_api.rst
+++ b/docs/source/python_api.rst
@@ -1,5 +1,5 @@
-SMAUG Operators
-=========
+SMAUG Python APIs
+=================
 
 .. toctree::
    :maxdepth: 1
@@ -9,9 +9,6 @@ SMAUG Operators
    nn
    math
    tensor
-
-Building new SMAUG features
-==========
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/python_tutorials.rst
+++ b/docs/source/python_tutorials.rst
@@ -2,7 +2,7 @@ Tutorials
 =========
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    build_python_model
    add_python_operator

--- a/docs/source/python_tutorials.rst
+++ b/docs/source/python_tutorials.rst
@@ -2,8 +2,7 @@ Tutorials
 =========
 
 .. toctree::
-   :maxdepth: 1
-   :caption: Tutorials
+   :maxdepth: 2
 
    build_python_model
    add_python_operator


### PR DESCRIPTION
A few cosmetics are added to make the docs page a bit nicer:

1) Add a sidebar entry for the C++ docs.
2) Increase the toctree depth visibility of the main page.
3) Reorganize the internal modules into the SMAUG Python APIs.