### PR TITLE
core: Remove the AllCache memory policy.

### DIFF
--- a/smaug/core/network_builder.cpp
+++ b/smaug/core/network_builder.cpp
@@ -288,10 +288,6 @@ static void createAndAddOperator(const NodeProto& node,
         op->setInputsMemType(MemoryType::acp);
         op->setWeightsMemType(MemoryType::acp);
         op->setOutputsMemType(MemoryType::acp);
-    } else if (memPolicy == HostMemoryAccessPolicy::AllCache) {
-        op->setInputsMemType(MemoryType::cache);
-        op->setWeightsMemType(MemoryType::cache);
-        op->setOutputsMemType(MemoryType::cache);
     } else if (memPolicy == HostMemoryAccessPolicy::AllAcpWithDmaForWeights) {
         op->setInputsMemType(MemoryType::acp);
         op->setWeightsMemType(MemoryType::dma);

--- a/smaug/core/types.proto
+++ b/smaug/core/types.proto
@@ -77,6 +77,6 @@ enum HostMemoryAccessPolicy {
   UnknownMemoryPolicy = 0;
   AllDma = 1;
   AllAcp = 2;
-  AllCache = 3;
+  reserved 3;  // Previously AllCache.
   AllAcpWithDmaForWeights = 4;
 }


### PR DESCRIPTION
AllCache as a memory policy doesn't make sense. A MemoryPolicy specifies
*how* the data is moved, not where it gets stored after it is moved.
The latter is specified in the Aladdin config files (scratchpads or
caches). This option, when used, causes simulations to fail because
the logic to handle this case was not added for
HybridDatapath::handleCacheMemoryOp; however, in practice it is almost
the same as using ACP, which *does* handle it. So, we just drop this
policy as an option altogether.

Fixes issue #102.